### PR TITLE
 Tagged threads for jobs, batches, and timers

### DIFF
--- a/lokimq/auth.cpp
+++ b/lokimq/auth.cpp
@@ -204,7 +204,7 @@ void LokiMQ::process_zap_requests() {
                 else
                     o << v;
             }
-            log_(LogLevel::trace, __FILE__, __LINE__, o.str());
+            log(LogLevel::trace, __FILE__, __LINE__, o.str());
         } else
 #endif
             LMQ_LOG(debug, "Processing ZAP authentication request");

--- a/lokimq/batch.h
+++ b/lokimq/batch.h
@@ -36,18 +36,25 @@ namespace lokimq {
 
 namespace detail {
 
-enum class BatchStatus {
+enum class BatchState {
     running, // there are still jobs to run (or running)
     complete, // the batch is complete but still has a completion job to call
-    complete_proxy, // same as `complete`, but the completion job should be invoked immediately in the proxy thread (be very careful)
     done // the batch is complete and has no completion function
+};
+
+struct BatchStatus {
+    BatchState state;
+    int thread;
 };
 
 // Virtual base class for Batch<R>
 class Batch {
 public:
-    // Returns the number of jobs in this batch
-    virtual size_t size() const = 0;
+    // Returns the number of jobs in this batch and whether any of them are thread-specific
+    virtual std::pair<size_t, bool> size() const = 0;
+    // Returns a vector of exactly the same length of size().first containing the tagged thread ids
+    // of the batch jobs or 0 for general jobs.
+    virtual std::vector<int> threads() const = 0;
     // Called in a worker thread to run the job
     virtual void run_job(int i) = 0;
     // Called in the main proxy thread when the worker returns from finishing a job.  The return
@@ -151,12 +158,13 @@ public:
     Batch &operator=(const Batch&) = delete;
 
 private:
-    std::vector<std::function<R()>> jobs;
+    std::vector<std::pair<std::function<R()>, int>> jobs;
     std::vector<job_result<R>> results;
     CompletionFunc complete;
     std::size_t jobs_outstanding = 0;
-    bool complete_in_proxy = false;
+    int complete_in_thread = 0;
     bool started = false;
+    bool tagged_thread_jobs = false;
 
     void check_not_started() {
         if (started)
@@ -175,38 +183,60 @@ public:
     /// available.  The called function may throw exceptions (which will be propagated to the
     /// completion function through the job_result values).  There is no guarantee on the order of
     /// invocation of the jobs.
-    void add_job(std::function<R()> job) {
+    ///
+    /// \param job the callback
+    /// \param thread an optional TaggedThread on which this job must run
+    void add_job(std::function<R()> job, const TaggedThread* thread = nullptr) { 
         check_not_started();
-        jobs.emplace_back(std::move(job));
-        results.emplace_back();
-        jobs_outstanding++;
+        if (thread && thread->_id == -1)
+            // There are some special case internal jobs where we allow this, but they use the
+            // private method below that doesn't have this check.
+            throw std::logic_error{"Cannot add a proxy thread batch job -- this makes no sense"};
+        add_job(std::move(job), thread ? thread->_id : 0);
     }
 
     /// Sets the completion function to invoke after all jobs have finished.  If this is not set
     /// then jobs simply run and results are discarded.
-    void completion(CompletionFunc comp) {
+    ///
+    /// \param comp - function to call when all jobs have finished
+    /// \param thread - optional tagged thread in which to schedule the completion job.  If not
+    /// provided then the completion job is scheduled in the pool of batch job threads.
+    ///
+    /// `thread` can be provided the value &LokiMQ::run_in_proxy to invoke the completion function
+    /// *IN THE PROXY THREAD* itself after all jobs have finished.  Be very, very careful: this
+    /// should be a nearly trivial job that does not require any substantial CPU time and does not
+    /// block for any reason.  This is only intended for the case where the completion job is so
+    /// trivial that it will take less time than simply queuing the job to be executed by another
+    /// thread.
+    void completion(CompletionFunc comp, const TaggedThread* thread = nullptr) {
         check_not_started();
         if (complete)
             throw std::logic_error("Completion function can only be set once");
         complete = std::move(comp);
-    }
-
-    /// Sets a completion function to invoke *IN THE PROXY THREAD* after all jobs have finished.  Be
-    /// very, very careful: this should not be a job that takes any significant amount of CPU time
-    /// or can block for any reason (NO MUTEXES).
-    void completion_proxy(CompletionFunc comp) {
-        check_not_started();
-        if (complete)
-            throw std::logic_error("Completion function can only be set once");
-        complete = std::move(comp);
-        complete_in_proxy = true;
+        complete_in_thread = thread ? thread->_id : 0;
     }
 
 private:
 
-    std::size_t size() const override {
-        return jobs.size();
+    void add_job(std::function<R()> job, int thread_id) {
+        jobs.emplace_back(std::move(job), thread_id);
+        results.emplace_back();
+        jobs_outstanding++;
+        if (thread_id != 0)
+            tagged_thread_jobs = true;
     }
+
+    std::pair<std::size_t, bool> size() const override {
+        return {jobs.size(), tagged_thread_jobs};
+    }
+
+    std::vector<int> threads() const override {
+        std::vector<int> t;
+        t.reserve(jobs.size());
+        for (auto& j : jobs)
+            t.push_back(j.second);
+        return t;
+    };
 
     template <typename S = R>
     void set_value(job_result<S>& r, std::function<S()>& f) { r.set_value(f()); }
@@ -216,7 +246,7 @@ private:
         // called by worker thread
         auto& r = results[i];
         try {
-            set_value(r, jobs[i]);
+            set_value(r, jobs[i].first);
         } catch (...) {
             r.set_exception(std::current_exception());
         }
@@ -225,12 +255,10 @@ private:
     detail::BatchStatus job_finished() override {
         --jobs_outstanding;
         if (jobs_outstanding)
-            return detail::BatchStatus::running;
+            return {detail::BatchState::running, 0};
         if (complete)
-            return complete_in_proxy
-                ? detail::BatchStatus::complete_proxy
-                : detail::BatchStatus::complete;
-        return detail::BatchStatus::done;
+            return {detail::BatchState::complete, complete_in_thread};
+        return {detail::BatchState::done, 0};
     }
 
     void job_completion() override {
@@ -241,7 +269,7 @@ private:
 
 template <typename R>
 void LokiMQ::batch(Batch<R>&& batch) {
-    if (batch.size() == 0)
+    if (batch.size().first == 0)
         throw std::logic_error("Cannot batch a a job batch with 0 jobs");
     // Need to send this over to the proxy thread via the base class pointer.  It assumes ownership.
     auto* baseptr = static_cast<detail::Batch*>(new Batch<R>(std::move(batch)));

--- a/lokimq/batch.h
+++ b/lokimq/batch.h
@@ -185,8 +185,8 @@ public:
     /// invocation of the jobs.
     ///
     /// \param job the callback
-    /// \param thread an optional TaggedThread on which this job must run
-    void add_job(std::function<R()> job, const TaggedThread* thread = nullptr) { 
+    /// \param thread an optional TaggedThreadID indicating a thread in which this job must run
+    void add_job(std::function<R()> job, std::optional<TaggedThreadID> thread = std::nullopt) {
         check_not_started();
         if (thread && thread->_id == -1)
             // There are some special case internal jobs where we allow this, but they use the
@@ -208,7 +208,7 @@ public:
     /// block for any reason.  This is only intended for the case where the completion job is so
     /// trivial that it will take less time than simply queuing the job to be executed by another
     /// thread.
-    void completion(CompletionFunc comp, const TaggedThread* thread = nullptr) {
+    void completion(CompletionFunc comp, std::optional<TaggedThreadID> thread = std::nullopt) {
         check_not_started();
         if (complete)
             throw std::logic_error("Completion function can only be set once");

--- a/lokimq/jobs.cpp
+++ b/lokimq/jobs.cpp
@@ -6,15 +6,31 @@ namespace lokimq {
 
 void LokiMQ::proxy_batch(detail::Batch* batch) {
     batches.insert(batch);
-    const int jobs = batch->size();
-    for (int i = 0; i < jobs; i++)
-        batch_jobs.emplace(batch, i);
+    const auto [jobs, tagged_threads] = batch->size();
+    LMQ_TRACE("proxy queuing batch job with ", jobs, " jobs", tagged_threads ? " (job uses tagged thread(s))" : "");
+    if (!tagged_threads) {
+        for (size_t i = 0; i < jobs; i++)
+            batch_jobs.emplace(batch, i);
+    } else {
+        // Some (or all) jobs have a specific thread target so queue any such jobs in the tagged
+        // worker queue.
+        auto threads = batch->threads();
+        for (size_t i = 0; i < jobs; i++) {
+            auto& jobs = threads[i] > 0
+                ? std::get<std::queue<batch_job>>(tagged_workers[threads[i] - 1])
+                : batch_jobs;
+            jobs.emplace(batch, i);
+        }
+    }
+
     proxy_skip_one_poll = true;
 }
 
-void LokiMQ::job(std::function<void()> f) {
+void LokiMQ::job(std::function<void()> f, const TaggedThread* thread) {
+    if (thread && thread->_id == -1)
+        throw std::logic_error{"job() cannot be used to queue an in-proxy job"};
     auto* b = new Batch<void>;
-    b->add_job(std::move(f));
+    b->add_job(std::move(f), thread);
     auto* baseptr = static_cast<detail::Batch*>(b);
     detail::send_control(get_control_socket(), "BATCH", bt_serialize(reinterpret_cast<uintptr_t>(baseptr)));
 }
@@ -38,7 +54,7 @@ void LokiMQ::proxy_run_batch_jobs(std::queue<batch_job>& jobs, const int reserve
 
 // Called either within the proxy thread, or before the proxy thread has been created; actually adds
 // the timer.  If the timer object hasn't been set up yet it gets set up here.
-void LokiMQ::proxy_timer(std::function<void()> job, std::chrono::milliseconds interval, bool squelch) {
+void LokiMQ::proxy_timer(std::function<void()> job, std::chrono::milliseconds interval, bool squelch, int thread) {
     if (!timers)
         timers.reset(zmq_timers_new());
 
@@ -48,16 +64,17 @@ void LokiMQ::proxy_timer(std::function<void()> job, std::chrono::milliseconds in
             this);
     if (timer_id == -1)
         throw zmq::error_t{};
-    timer_jobs[timer_id] = std::make_tuple(std::move(job), squelch, false);
+    timer_jobs[timer_id] = { std::move(job), squelch, false, thread };
 }
 
 void LokiMQ::proxy_timer(bt_list_consumer timer_data) {
     std::unique_ptr<std::function<void()>> func{reinterpret_cast<std::function<void()>*>(timer_data.consume_integer<uintptr_t>())};
     auto interval = std::chrono::milliseconds{timer_data.consume_integer<uint64_t>()};
     auto squelch = timer_data.consume_integer<bool>();
+    auto thread = timer_data.consume_integer<int>();
     if (!timer_data.is_finished())
         throw std::runtime_error("Internal error: proxied timer request contains unexpected data");
-    proxy_timer(std::move(*func), interval, squelch);
+    proxy_timer(std::move(*func), interval, squelch, thread);
 }
 
 void LokiMQ::_queue_timer_job(int timer_id) {
@@ -66,43 +83,75 @@ void LokiMQ::_queue_timer_job(int timer_id) {
         LMQ_LOG(warn, "Could not find timer job ", timer_id);
         return;
     }
-    auto& timer = it->second;
-    auto& squelch = std::get<1>(timer);
-    auto& running = std::get<2>(timer);
+    auto& [func, squelch, running, thread] = it->second;
     if (squelch && running) {
         LMQ_LOG(debug, "Not running timer job ", timer_id, " because a job for that timer is still running");
         return;
     }
 
+    if (thread == -1) { // Run directly in proxy thread
+        try { func(); }
+        catch (const std::exception &e) { LMQ_LOG(warn, "timer job ", timer_id, " raised an exception: ", e.what()); }
+        catch (...) { LMQ_LOG(warn, "timer job ", timer_id, " raised a non-std exception"); }
+        return;
+    }
+
     auto* b = new Batch<void>;
-    b->add_job(std::get<0>(timer));
+    b->add_job(func, thread);
     if (squelch) {
         running = true;
-        b->completion_proxy([this,timer_id](auto results) {
+        b->completion([this,timer_id](auto results) {
             try { results[0].get(); }
             catch (const std::exception &e) { LMQ_LOG(warn, "timer job ", timer_id, " raised an exception: ", e.what()); }
             catch (...) { LMQ_LOG(warn, "timer job ", timer_id, " raised a non-std exception"); }
             auto it = timer_jobs.find(timer_id);
             if (it != timer_jobs.end())
-                std::get<2>(it->second)/*running*/ = false;
-        });
+                it->second.running = false;
+        }, &LokiMQ::run_in_proxy);
     }
     batches.insert(b);
-    batch_jobs.emplace(static_cast<detail::Batch*>(b), 0);
-    assert(b->size() == 1);
+    LMQ_TRACE("b: ", b->size().first, ", ", b->size().second, "; thread = ", thread);
+    assert(b->size() == std::make_pair(size_t{1}, thread > 0));
+    auto& queue = thread > 0
+        ? std::get<std::queue<batch_job>>(tagged_workers[thread - 1])
+        : batch_jobs;
+    queue.emplace(static_cast<detail::Batch*>(b), 0);
 }
 
-void LokiMQ::add_timer(std::function<void()> job, std::chrono::milliseconds interval, bool squelch) {
+void LokiMQ::add_timer(std::function<void()> job, std::chrono::milliseconds interval, bool squelch, const TaggedThread* thread) {
+    int th_id = thread ? thread->_id : 0;
     if (proxy_thread.joinable()) {
         detail::send_control(get_control_socket(), "TIMER", bt_serialize(bt_list{{
                     detail::serialize_object(std::move(job)),
                     interval.count(),
-                    squelch}}));
+                    squelch,
+                    th_id}}));
     } else {
-        proxy_timer(std::move(job), interval, squelch);
+        proxy_timer(std::move(job), interval, squelch, th_id);
     }
 }
 
 void LokiMQ::TimersDeleter::operator()(void* timers) { zmq_timers_destroy(&timers); }
+
+TaggedThread LokiMQ::add_tagged_thread(std::string name, std::function<void()> init, std::function<void()> start) {
+    if (proxy_thread.joinable())
+        throw std::logic_error{"Cannot add tagged threads after calling `start()`"};
+
+    if (name == "_proxy"sv || name.empty() || name.find('\0') != std::string::npos)
+        throw std::logic_error{"Invalid tagged thread name `" + name + "'"};
+
+    auto& [run, busy, queue] = tagged_workers.emplace_back();
+    busy = false;
+    run.worker_id = tagged_workers.size(); // We want index + 1 (b/c 0 is used for non-tagged jobs)
+    run.worker_routing_id = "t" + std::to_string(run.worker_id);
+    LMQ_TRACE("Created new tagged thread ", name, " with routing id ", run.worker_routing_id);
+
+    run.worker_thread = std::thread{[this, id=run.worker_id, name, init=std::move(init), start=std::move(start)] {
+        if (init) init();
+        return worker_thread(id, name, std::move(start));
+    }};
+
+    return {std::move(name), static_cast<int>(run.worker_id)};
+}
 
 }

--- a/lokimq/jobs.cpp
+++ b/lokimq/jobs.cpp
@@ -146,10 +146,7 @@ TaggedThreadID LokiMQ::add_tagged_thread(std::string name, std::function<void()>
     run.worker_routing_id = "t" + std::to_string(run.worker_id);
     LMQ_TRACE("Created new tagged thread ", name, " with routing id ", run.worker_routing_id);
 
-    run.worker_thread = std::thread{[this, id=run.worker_id, name, init=std::move(init), start=std::move(start)] {
-        if (init) init();
-        return worker_thread(id, name, std::move(start));
-    }};
+    run.worker_thread = std::thread{&LokiMQ::worker_thread, this, run.worker_id, name, std::move(start)};
 
     return TaggedThreadID{static_cast<int>(run.worker_id)};
 }

--- a/lokimq/lokimq-internal.h
+++ b/lokimq/lokimq-internal.h
@@ -4,12 +4,11 @@
 // Inside some method:
 //     LMQ_LOG(warn, "bad ", 42, " stuff");
 //
-// (The "this->" is here to work around gcc 5 bugginess when called in a `this`-capturing lambda.)
-#define LMQ_LOG(level, ...) this->log_(LogLevel::level, __FILE__, __LINE__, __VA_ARGS__)
+#define LMQ_LOG(level, ...) log(LogLevel::level, __FILE__, __LINE__, __VA_ARGS__)
 
 #ifndef NDEBUG
 // Same as LMQ_LOG(trace, ...) when not doing a release build; nothing under a release build.
-#  define LMQ_TRACE(...) this->log_(LogLevel::trace, __FILE__, __LINE__, __VA_ARGS__)
+#  define LMQ_TRACE(...) log(LogLevel::trace, __FILE__, __LINE__, __VA_ARGS__)
 #else
 #  define LMQ_TRACE(...)
 #endif

--- a/lokimq/lokimq.cpp
+++ b/lokimq/lokimq.cpp
@@ -348,6 +348,7 @@ LokiMQ::run_info& LokiMQ::run_info::load(category* cat_, std::string command_, C
                 std::vector<zmq::message_t> data_parts_, const std::pair<CommandCallback, bool>* callback_) {
     is_batch_job = false;
     is_reply_job = false;
+    is_tagged_thread_job = false;
     cat = cat_;
     command = std::move(command_);
     conn = std::move(conn_);
@@ -363,9 +364,10 @@ LokiMQ::run_info& LokiMQ::run_info::load(pending_command&& pending) {
             std::move(pending.remote), std::move(pending.data_parts), pending.callback);
 }
 
-LokiMQ::run_info& LokiMQ::run_info::load(batch_job&& bj, bool reply_job) {
+LokiMQ::run_info& LokiMQ::run_info::load(batch_job&& bj, bool reply_job, int tagged_thread) {
     is_batch_job = true;
     is_reply_job = reply_job;
+    is_tagged_thread_job = tagged_thread > 0;
     batch_jobno = bj.second;
     batch = bj.first;
     return *this;

--- a/lokimq/lokimq.h
+++ b/lokimq/lokimq.h
@@ -838,7 +838,7 @@ public:
      * \returns a TaggedThreadID object that can be passed to job(), batch(), or add_timer() to
      * direct the task to the tagged thread.
      */
-    TaggedThreadID add_tagged_thread(std::string name, std::function<void()> init = nullptr, std::function<void()> start = nullptr);
+    TaggedThreadID add_tagged_thread(std::string name, std::function<void()> start = nullptr);
 
     /**
      * Sets the number of worker threads reserved for batch jobs.  If not explicitly called then

--- a/lokimq/lokimq.h
+++ b/lokimq/lokimq.h
@@ -268,6 +268,10 @@ public:
     /// to direct very simple batch completion jobs to be executed directly in the proxy thread.
     inline static const TaggedThread run_in_proxy{"_proxy", -1};
 
+    /// Writes a message to the logging system; intended mostly for internal use.
+    template <typename... T>
+    void log(LogLevel lvl, const char* filename, int line, const T&... stuff);
+
 private:
 
     /// The lookup function that tells us where to connect to a peer, or empty if not found.
@@ -279,10 +283,6 @@ private:
 
     /// The callback to call with log messages
     Logger logger;
-
-    /// Logging implementation
-    template <typename... T>
-    void log_(LogLevel lvl, const char* filename, int line, const T&... stuff);
 
     ///////////////////////////////////////////////////////////////////////////////////
     /// NB: The following are all the domain of the proxy thread (once it is started)!
@@ -1433,7 +1433,7 @@ inline std::string_view trim_log_filename(std::string_view local_file) {
 }
 
 template <typename... T>
-void LokiMQ::log_(LogLevel lvl, const char* file, int line, const T&... stuff) {
+void LokiMQ::log(LogLevel lvl, const char* file, int line, const T&... stuff) {
     if (log_level() < lvl)
         return;
 

--- a/lokimq/lokimq.h
+++ b/lokimq/lokimq.h
@@ -816,8 +816,8 @@ public:
     void add_command_alias(std::string from, std::string to);
 
     /** Creates a "tagged thread" and starts it immediately.  A tagged thread is one that batches,
-     * jobs, and timer jobs can be sent to by specifically, typically to perform coordination of
-     * some thread-unsafe work.
+     * jobs, and timer jobs can be sent to specifically, typically to perform coordination of some
+     * thread-unsafe work.
      *
      * Tagged threads will *only* process jobs sent specifically to them; they do not participate in
      * the thread pool used for regular jobs.  Each tagged thread also has its own job queue

--- a/lokimq/proxy.cpp
+++ b/lokimq/proxy.cpp
@@ -104,7 +104,6 @@ void LokiMQ::proxy_send(bt_dict_consumer data) {
     // connections open to that SN (e.g. one out + one in) so if one fails we can clean up that
     // connection and try the next one.
     bool retry = true, sent = false, nowarn = false;
-    std::unique_ptr<zmq::error_t> send_error;
     while (retry) {
         retry = false;
         zmq::socket_t *send_to;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ set(LMQ_TEST_SRC
     test_encoding.cpp
     test_failures.cpp
     test_requests.cpp
+    test_tagged_threads.cpp
     )
 
 add_executable(tests ${LMQ_TEST_SRC})

--- a/tests/test_commands.cpp
+++ b/tests/test_commands.cpp
@@ -202,7 +202,8 @@ TEST_CASE("deferred replies on incoming connections", "[commands][hey google]") 
     LokiMQ nsa{get_logger("NSA» ")};
     nsa.add_category("backdoor", Access{AuthLevel::admin});
     nsa.add_command("backdoor", "data", [&](Message& m) {
-            backdoor_details.emplace(m.data[0]);
+        auto l = catch_lock();
+        backdoor_details.emplace(m.data[0]);
     });
     nsa.start();
     auto nsa_c = nsa.connect_remote(listen, connect_success, connect_failure, server.get_pubkey(), AuthLevel::admin);
@@ -252,7 +253,7 @@ TEST_CASE("deferred replies on incoming connections", "[commands][hey google]") 
                 },
                 personal_detail);
     }
-    wait_for([&] { auto lock = catch_lock(); return things_remembered == all_the_things.size(); });
+    wait_for([&] { auto lock = catch_lock(); return things_remembered == all_the_things.size() && things_remembered == backdoor_details.size(); });
     {
         auto l = catch_lock();
         REQUIRE( things_remembered == all_the_things.size() );

--- a/tests/test_tagged_threads.cpp
+++ b/tests/test_tagged_threads.cpp
@@ -48,7 +48,7 @@ TEST_CASE("batch jobs to tagged threads", "[tagged][batch]") {
     }
     
     done = false;
-    lmq.job([&] { id = std::this_thread::get_id(); done = true; }, &t_abc);
+    lmq.job([&] { id = std::this_thread::get_id(); done = true; }, t_abc);
     wait_for([&] { return done.load(); });
     {
         auto lock = catch_lock();
@@ -56,7 +56,7 @@ TEST_CASE("batch jobs to tagged threads", "[tagged][batch]") {
     }
 
     done = false;
-    lmq.job([&] { id = std::this_thread::get_id(); done = true; }, &t_def);
+    lmq.job([&] { id = std::this_thread::get_id(); done = true; }, t_def);
     wait_for([&] { return done.load(); });
     {
         auto lock = catch_lock();
@@ -74,7 +74,7 @@ TEST_CASE("batch jobs to tagged threads", "[tagged][batch]") {
     std::this_thread::sleep_for(50ms);
 
     done = false;
-    lmq.job([&] { id = std::this_thread::get_id(); done = true; }, &t_abc);
+    lmq.job([&] { id = std::this_thread::get_id(); done = true; }, t_abc);
     wait_for([&] { return done.load(); });
     {
         auto lock = catch_lock();
@@ -86,9 +86,9 @@ TEST_CASE("batch jobs to tagged threads", "[tagged][batch]") {
     // We can queue up a bunch of jobs which should all happen in order, and all on the abc thread.
     std::vector<int> v;
     for (int i = 0; i < 100; i++) {
-        lmq.job([&] { if (std::this_thread::get_id() == id_abc) v.push_back(v.size()); }, &t_abc);
+        lmq.job([&] { if (std::this_thread::get_id() == id_abc) v.push_back(v.size()); }, t_abc);
     }
-    lmq.job([&] { done = true; }, &t_abc);
+    lmq.job([&] { done = true; }, t_abc);
     wait_for([&] { return done.load(); });
     {
         auto lock = catch_lock();
@@ -125,7 +125,7 @@ TEST_CASE("batch job completion on tagged threads", "[tagged][batch-completion]"
         for (auto& r : result)
             sum += r.get();
         result_sum = std::this_thread::get_id() == id_abc ? sum : -sum;
-    }, &t_abc);
+    }, t_abc);
     lmq.batch(std::move(batch));
     wait_for([&] { return result_sum.load() != -1; });
     {
@@ -148,7 +148,7 @@ TEST_CASE("timer job completion on tagged threads", "[tagged][timer]") {
     std::atomic<int> ticks = 0;
     std::atomic<int> abc_ticks = 0;
     lmq.add_timer([&] { ticks++; }, 10ms);
-    lmq.add_timer([&] { if (std::this_thread::get_id() == id_abc) abc_ticks++; }, 10ms, true, &t_abc);
+    lmq.add_timer([&] { if (std::this_thread::get_id() == id_abc) abc_ticks++; }, 10ms, true, t_abc);
 
     wait_for([&] { return ticks.load() > 2 && abc_ticks > 2; });
     {

--- a/tests/test_tagged_threads.cpp
+++ b/tests/test_tagged_threads.cpp
@@ -1,0 +1,161 @@
+#include "lokimq/batch.h"
+#include "common.h"
+#include <future>
+
+TEST_CASE("tagged thread init and start functions", "[tagged][init]") {
+    lokimq::LokiMQ lmq{get_logger(""), LogLevel::trace};
+
+    lmq.set_general_threads(2);
+    lmq.set_batch_threads(2);
+    auto t_abc = lmq.add_tagged_thread("abc");
+    std::atomic<bool> init_called = false, initghi_called = false, start_called = false;
+    auto t_def = lmq.add_tagged_thread("def", [&] { init_called = true; });
+    auto t_ghi = lmq.add_tagged_thread("def", [&] { initghi_called = true; }, [&] { start_called = false; });
+
+    wait_for([&] { return init_called.load() && initghi_called.load(); });
+    {
+        auto lock = catch_lock();
+        REQUIRE_FALSE( start_called );
+    }
+
+    lmq.start();
+    wait_for([&] { return start_called.load(); });
+    {
+        auto lock = catch_lock();
+        REQUIRE_FALSE( start_called );
+    }
+}
+
+
+TEST_CASE("batch jobs to tagged threads", "[tagged][batch]") {
+    lokimq::LokiMQ lmq{get_logger(""), LogLevel::trace};
+
+    lmq.set_general_threads(2);
+    lmq.set_batch_threads(2);
+    std::thread::id id_abc, id_def;
+    auto t_abc = lmq.add_tagged_thread("abc", [&] { id_abc = std::this_thread::get_id(); });
+    auto t_def = lmq.add_tagged_thread("def", [&] { id_def = std::this_thread::get_id(); });
+    lmq.start();
+
+    std::atomic<bool> done = false;
+    std::thread::id id;
+    lmq.job([&] { id = std::this_thread::get_id(); done = true; });
+    wait_for([&] { return done.load(); });
+    {
+        auto lock = catch_lock();
+        REQUIRE( id != id_abc );
+        REQUIRE( id != id_def );
+    }
+    
+    done = false;
+    lmq.job([&] { id = std::this_thread::get_id(); done = true; }, &t_abc);
+    wait_for([&] { return done.load(); });
+    {
+        auto lock = catch_lock();
+        REQUIRE( id == id_abc );
+    }
+
+    done = false;
+    lmq.job([&] { id = std::this_thread::get_id(); done = true; }, &t_def);
+    wait_for([&] { return done.load(); });
+    {
+        auto lock = catch_lock();
+        REQUIRE( id == id_def );
+    }
+
+    std::atomic<bool> sleep = true;
+    auto sleeper = [&] { for (int i = 0; sleep && i < 10; i++) { std::this_thread::sleep_for(25ms); } };
+    lmq.job(sleeper);
+    lmq.job(sleeper);
+    // This one should stall:
+    std::atomic<bool> bad = false;
+    lmq.job([&] { bad = true; });
+
+    std::this_thread::sleep_for(50ms);
+
+    done = false;
+    lmq.job([&] { id = std::this_thread::get_id(); done = true; }, &t_abc);
+    wait_for([&] { return done.load(); });
+    {
+        auto lock = catch_lock();
+        REQUIRE( done.load() );
+        REQUIRE_FALSE( bad.load() );
+    }
+
+    done = false;
+    // We can queue up a bunch of jobs which should all happen in order, and all on the abc thread.
+    std::vector<int> v;
+    for (int i = 0; i < 100; i++) {
+        lmq.job([&] { if (std::this_thread::get_id() == id_abc) v.push_back(v.size()); }, &t_abc);
+    }
+    lmq.job([&] { done = true; }, &t_abc);
+    wait_for([&] { return done.load(); });
+    {
+        auto lock = catch_lock();
+        REQUIRE( done.load() );
+        REQUIRE_FALSE( bad.load() );
+        REQUIRE( v.size() == 100 );
+        for (int i = 0; i < 100; i++)
+            REQUIRE( v[i] == i );
+    }
+    sleep = false;
+    wait_for([&] { return bad.load(); });
+    {
+        auto lock = catch_lock();
+        REQUIRE( bad.load() );
+    }
+}
+
+TEST_CASE("batch job completion on tagged threads", "[tagged][batch-completion]") {
+    lokimq::LokiMQ lmq{get_logger(""), LogLevel::trace};
+
+    lmq.set_general_threads(4);
+    lmq.set_batch_threads(4);
+    std::thread::id id_abc;
+    auto t_abc = lmq.add_tagged_thread("abc", [&] { id_abc = std::this_thread::get_id(); });
+    lmq.start();
+
+    lokimq::Batch<int> batch;
+    for (int i = 1; i < 10; i++)
+        batch.add_job([i, &id_abc]() { if (std::this_thread::get_id() == id_abc) return 0; return i; });
+
+    std::atomic<int> result_sum = -1;
+    batch.completion([&](auto result) {
+        int sum = 0;
+        for (auto& r : result)
+            sum += r.get();
+        result_sum = std::this_thread::get_id() == id_abc ? sum : -sum;
+    }, &t_abc);
+    lmq.batch(std::move(batch));
+    wait_for([&] { return result_sum.load() != -1; });
+    {
+        auto lock = catch_lock();
+        REQUIRE( result_sum == 45 );
+    }
+}
+
+
+TEST_CASE("timer job completion on tagged threads", "[tagged][timer]") {
+    lokimq::LokiMQ lmq{get_logger(""), LogLevel::trace};
+
+    lmq.set_general_threads(4);
+    lmq.set_batch_threads(4);
+
+    std::thread::id id_abc;
+    auto t_abc = lmq.add_tagged_thread("abc", [&] { id_abc = std::this_thread::get_id(); });
+    lmq.start();
+
+    std::atomic<int> ticks = 0;
+    std::atomic<int> abc_ticks = 0;
+    lmq.add_timer([&] { ticks++; }, 10ms);
+    lmq.add_timer([&] { if (std::this_thread::get_id() == id_abc) abc_ticks++; }, 10ms, true, &t_abc);
+
+    wait_for([&] { return ticks.load() > 2 && abc_ticks > 2; });
+    {
+        auto lock = catch_lock();
+        REQUIRE( ticks.load() > 2 );
+        REQUIRE( abc_ticks.load() > 2 );
+    }
+}
+
+

--- a/tests/test_tagged_threads.cpp
+++ b/tests/test_tagged_threads.cpp
@@ -2,17 +2,16 @@
 #include "common.h"
 #include <future>
 
-TEST_CASE("tagged thread init and start functions", "[tagged][init]") {
+TEST_CASE("tagged thread start functions", "[tagged][start]") {
     lokimq::LokiMQ lmq{get_logger(""), LogLevel::trace};
 
     lmq.set_general_threads(2);
     lmq.set_batch_threads(2);
     auto t_abc = lmq.add_tagged_thread("abc");
-    std::atomic<bool> init_called = false, initghi_called = false, start_called = false;
-    auto t_def = lmq.add_tagged_thread("def", [&] { init_called = true; });
-    auto t_ghi = lmq.add_tagged_thread("def", [&] { initghi_called = true; }, [&] { start_called = false; });
+    std::atomic<bool> start_called = false;
+    auto t_def = lmq.add_tagged_thread("def", [&] { start_called = true; });
 
-    wait_for([&] { return init_called.load() && initghi_called.load(); });
+    std::this_thread::sleep_for(20ms);
     {
         auto lock = catch_lock();
         REQUIRE_FALSE( start_called );
@@ -22,7 +21,7 @@ TEST_CASE("tagged thread init and start functions", "[tagged][init]") {
     wait_for([&] { return start_called.load(); });
     {
         auto lock = catch_lock();
-        REQUIRE_FALSE( start_called );
+        REQUIRE( start_called );
     }
 }
 


### PR DESCRIPTION
This adds to ability to have lokimq manage specific threads to which jobs (individual, batch jobs, batch completions, or timers) can be directed to.  This allows dedicating a thread to some slow or thread-unsafe action where you can dump jobs to the tagged thread as a method of lockless job queuing.

The basic functionality works like this:

```C++
LokiMQ lmq{...};
auto io_thread = lmq.add_tagged_thread("io");
lmq.start();

// ... later, from some thread that needs to queue things on the io thread:
lmq.job([this] { write_crap_to_disk(); }, &io_thread);
```
where the job is now guaranteed to run *only* on the "io" thread.  Such tagged threads do not participate in the general thread pool at all: they only receive tagged jobs (and receive *all* jobs tagged for them).