### PR TITLE
Take lokimq::address as connect_remote argument

### DIFF
--- a/lokimq/address.cpp
+++ b/lokimq/address.cpp
@@ -181,6 +181,20 @@ address::address(std::string_view addr) {
         throw std::invalid_argument{"Invalid trailing garbage '" + std::string{addr} + "' in address"};
 }
 
+address& address::set_pubkey(std::string_view pk) {
+    if (pk.size() == 0) {
+        if (protocol == proto::tcp_curve) protocol = proto::tcp;
+        else if (protocol == proto::ipc_curve) protocol = proto::ipc;
+    } else if (pk.size() == 32) {
+        if (protocol == proto::tcp) protocol = proto::tcp_curve;
+        else if (protocol == proto::ipc) protocol = proto::ipc_curve;
+    } else {
+        throw std::invalid_argument{"Invalid pubkey passed to set_pubkey(): require 0- or 32-byte pubkey"};
+    }
+    pubkey = pk;
+    return *this;
+}
+
 std::string address::encode_pubkey(encoding enc) const {
     std::string pk;
     if (enc == encoding::hex)

--- a/lokimq/address.h
+++ b/lokimq/address.h
@@ -120,6 +120,26 @@ struct address {
      */
     address(std::string_view addr);
 
+    /** Constructs an address from a remote string and a separate pubkey.  Typically `remote` is a
+     * basic ZMQ connect string, though this is not enforced.  Any pubkey information embedded in
+     * the remote string will be discarded and replaced with the given pubkey string.  The result
+     * will be curve encrypted if `pubkey` is non-empty, plaintext if `pubkey` is empty.
+     *
+     * Throws an exception if either addr or pubkey is invalid.
+     *
+     * Exactly equivalent to `address a{remote}; a.set_pubkey(pubkey);`
+     */
+    address(std::string_view addr, std::string_view pubkey) : address(addr) { set_pubkey(pubkey); }
+
+    /// Replaces the address's pubkey (if any) with the given pubkey (or no pubkey if empty).  If
+    /// changing from pubkey to no-pubkey or no-pubkey to pubkey then the protocol is update to
+    /// switch to or from curve encryption.
+    ///
+    /// pubkey should be the 32-byte binary pubkey, or an empty string to remove an existing pubkey.
+    ///
+    /// Returns the object itself, so that you can chain it.
+    address& set_pubkey(std::string_view pubkey);
+
     /// Constructs and builds the ZMQ connection address from the stored connection details.  This
     /// does not contain any of the curve-related details; those must be specified separately when
     /// interfacing with ZMQ.

--- a/tests/test_connect.cpp
+++ b/tests/test_connect.cpp
@@ -27,10 +27,9 @@ TEST_CASE("connections with curve authentication", "[curve][connect]") {
     auto pubkey = server.get_pubkey();
     std::atomic<bool> got{false};
     bool success = false;
-    auto server_conn = client.connect_remote(listen,
+    auto server_conn = client.connect_remote(address{listen, pubkey},
             [&](auto conn) { success = true; got = true; },
-            [&](auto conn, std::string_view reason) { auto lock = catch_lock(); INFO("connection failed: " << reason); got = true; },
-            pubkey);
+            [&](auto conn, std::string_view reason) { auto lock = catch_lock(); INFO("connection failed: " << reason); got = true; });
 
     wait_for_conn(got);
     {

--- a/tests/test_requests.cpp
+++ b/tests/test_requests.cpp
@@ -30,10 +30,9 @@ TEST_CASE("basic requests", "[requests]") {
     std::atomic<bool> connected{false}, failed{false};
     std::string pubkey;
 
-    auto c = client.connect_remote(listen,
+    auto c = client.connect_remote(address{listen, server.get_pubkey()},
             [&](auto conn) { pubkey = conn.pubkey(); connected = true; },
-            [&](auto, auto) { failed = true; },
-            server.get_pubkey());
+            [&](auto, auto) { failed = true; });
 
     wait_for([&] { return connected || failed; });
     {
@@ -88,10 +87,9 @@ TEST_CASE("request from server to client", "[requests]") {
     std::atomic<bool> connected{false}, failed{false};
     std::string pubkey;
 
-    auto c = client.connect_remote(listen,
+    auto c = client.connect_remote(address{listen, server.get_pubkey()},
             [&](auto conn) { pubkey = conn.pubkey(); connected = true; },
-            [&](auto, auto) { failed = true; },
-            server.get_pubkey());
+            [&](auto, auto) { failed = true; });
 
     int i;
     for (i = 0; i < 5; i++) {
@@ -151,10 +149,9 @@ TEST_CASE("request timeouts", "[requests][timeout]") {
     std::atomic<bool> connected{false}, failed{false};
     std::string pubkey;
 
-    auto c = client.connect_remote(listen,
+    auto c = client.connect_remote(address{listen, server.get_pubkey()},
             [&](auto conn) { pubkey = conn.pubkey(); connected = true; },
-            [&](auto, auto) { failed = true; },
-            server.get_pubkey());
+            [&](auto, auto) { failed = true; });
 
     wait_for([&] { return connected || failed; });
 


### PR DESCRIPTION
Deprecates the existing connect_remote() that takes remote addr and
pubkey as separate strings, just taking a `address` instead (into which
the caller can set pubkey/curve data as desired).

Also slightly changes how `connect_remote()` works when called with a
string remote but no pubkey: that string is now an augmented
lokimq::address string so that it can use the various formats supported
by `lokimq::address`.

(This was meant to be included in the PR that added `address` but
apparently didn't get implemented.)