### PR TITLE
Fix tagged workers not being properly shut down

### DIFF
--- a/tests/test_tagged_threads.cpp
+++ b/tests/test_tagged_threads.cpp
@@ -25,6 +25,11 @@ TEST_CASE("tagged thread start functions", "[tagged][start]") {
     }
 }
 
+TEST_CASE("tagged threads quit-before-start", "[tagged][quit]") {
+    auto lmq = std::make_unique<lokimq::LokiMQ>(get_logger(""), LogLevel::trace);
+    auto t_abc = lmq->add_tagged_thread("abc");
+    REQUIRE_NOTHROW(lmq.reset());
+}
 
 TEST_CASE("batch jobs to tagged threads", "[tagged][batch]") {
     lokimq::LokiMQ lmq{get_logger(""), LogLevel::trace};


### PR DESCRIPTION
If the LokiMQ object gets destroyed before having called `start()` then
we'd end up destroying the threads for tagged workers without joining
them.  This listens on the internal worker socket (normally the domain
of the proxy thread) and tells them to QUIT if such a destruction
happens.