### PR TITLE
ipc socket group ownership

### DIFF
--- a/lokimq/lokimq.h
+++ b/lokimq/lokimq.h
@@ -269,6 +269,9 @@ public:
     /** The gid that owns any sockets when constructed (same as umask)
      */
     int SOCKET_GID = -1;
+    /** The uid that owns any sockets when constructed (same as umask but requires root)
+     */
+    int SOCKET_UID = -1;
 
     /// A special TaggedThreadID value that always refers to the proxy thread; the main use of this is
     /// to direct very simple batch completion jobs to be executed directly in the proxy thread.

--- a/lokimq/lokimq.h
+++ b/lokimq/lokimq.h
@@ -266,6 +266,10 @@ public:
      */
     int STARTUP_UMASK = -1;
 
+    /** The gid that owns any sockets when constructed (same as umask)
+     */
+    int SOCKET_GID = -1;
+
     /// A special TaggedThreadID value that always refers to the proxy thread; the main use of this is
     /// to direct very simple batch completion jobs to be executed directly in the proxy thread.
     inline static constexpr TaggedThreadID run_in_proxy{-1};

--- a/lokimq/proxy.cpp
+++ b/lokimq/proxy.cpp
@@ -387,12 +387,12 @@ void LokiMQ::proxy_loop() {
     if (saved_umask != -1)
         umask(saved_umask);
 
-    // set socket gid if it is provided
-    if (SOCKET_GID != -1) {
+    // set socket gid / uid if it is provided
+    if (SOCKET_GID != -1 or SOCKET_UID != -1) {
         for(size_t i = 0; i < bind.size(); i++) {
             const address addr(bind[i].first);
             if(addr.ipc()) {
-                if(chown(addr.socket.c_str(), -1, SOCKET_GID) == -1) {
+                if(chown(addr.socket.c_str(), SOCKET_UID, SOCKET_GID) == -1) {
                     throw std::runtime_error("cannot set group on " + addr.socket + ": " + strerror(errno));
                 }
             }


### PR DESCRIPTION
allow an IPC socket to set which group it is owned by using SOCKET_GID similar to how STARTUP_UMASK is done.