### PR TITLE
Fix segfault on shutdown: Move socket holding into LokiMQ instance

### DIFF
--- a/lokimq/lokimq.h
+++ b/lokimq/lokimq.h
@@ -131,18 +131,15 @@ private:
 
     /// We have one seldom-used mutex here: it is generally locked just once per thread (the first
     /// time the thread calls get_control_socket()) and once more by the proxy thread when it shuts
-    /// down, and so will not be a contention point.
+    /// down.
     std::mutex control_sockets_mutex;
 
     /// Called to obtain a "command" socket that attaches to `control` to send commands to the
     /// proxy thread from other threads.  This socket is unique per thread and LokiMQ instance.
     zmq::socket_t& get_control_socket();
 
-    /// Stores all of the sockets created in different threads via `get_control_socket`.  This is
-    /// only used during destruction to close all of those open sockets, and is protected by an
-    /// internal mutex which is only locked by new threads getting a control socket and the
-    /// destructor.
-    std::vector<std::shared_ptr<zmq::socket_t>> thread_control_sockets;
+    /// Per-thread control sockets used by lokimq threads to talk to this object's proxy thread.
+    std::unordered_map<std::thread::id, std::unique_ptr<zmq::socket_t>> control_sockets;
 
 public:
 

--- a/lokimq/proxy.cpp
+++ b/lokimq/proxy.cpp
@@ -29,8 +29,6 @@ void LokiMQ::proxy_quit() {
     command.close();
     {
         std::lock_guard lock{control_sockets_mutex};
-        for (auto &control : thread_control_sockets)
-            control->close();
         proxy_shutting_down = true; // To prevent threads from opening new control sockets
     }
     workers_socket.close();


### PR DESCRIPTION
The thread_local `std::map` here can end up being destructed *before*
the LokiMQ instance (if both are being destroyed during thread joining),
in which case we segfault by trying to use the map.  Move the owning
container into the LokiMQ instead (indexed by the thread) to prevent
that.

Also cleans this code up by:

- Don't close control sockets from the proxy thread; socket_t's aren't
necessarily thread safe so this could be causing issues where we trouble
double-closing or using a closed socket.

- We can just let them get closed during destruction of the LokiMQ.

- Avoid needing shared_ptr's; instead we can just use a unique pointer
with raw pointers in the thread_local cache.  This simplifies closing
because all closing will happen during the LokiMQ destruction.

Fixes #24 