### PR TITLE
Make lokimq::is_hex check for size being a multiple of 2

### DIFF
--- a/tests/test_encoding.cpp
+++ b/tests/test_encoding.cpp
@@ -24,8 +24,15 @@ TEST_CASE("hex encoding/decoding", "[encoding][decoding][hex]") {
 
     REQUIRE( lokimq::is_hex("1234567890abcdefABCDEF1234567890abcdefABCDEF") );
     REQUIRE_FALSE( lokimq::is_hex("1234567890abcdefABCDEF1234567890aGcdefABCDEF") );
+    //                                                              ^
     REQUIRE_FALSE( lokimq::is_hex("1234567890abcdefABCDEF1234567890agcdefABCDEF") );
+    //                                                              ^
     REQUIRE_FALSE( lokimq::is_hex("\x11\xff") );
+    constexpr auto odd_hex = "1234567890abcdefABCDEF1234567890abcdefABCDE"sv;
+    REQUIRE_FALSE( lokimq::is_hex(odd_hex) );
+    REQUIRE_FALSE( lokimq::is_hex("0") );
+
+    REQUIRE( std::all_of(odd_hex.begin(), odd_hex.end(), lokimq::is_hex_digit<char>) );
 
     REQUIRE( lokimq::from_hex(pk_hex) == pk );
     REQUIRE( lokimq::to_hex(pk) == pk_hex );


### PR DESCRIPTION
`is_hex()` is a bit misleading as `from_hex()` requires an even-length hex string, but `is_hex()` also allows odd-length hex strings, which means currently callers should be doing `if (lokimq::is_hex(str) && str.size() % 2 == 0)`, but probably aren't.

Since the main point of `lokimq/hex.h` is for byte<->hex conversions it doesn't make much sense to allow `is_hex()` to return true for something that can't be validly decoded via `from_hex()`, thus this PR changes it to return false.

If someone *really* wants to test for an odd-length hex string, this also exposes `is_hex_digit` so that they could use:
```C++
bool all_hex = std::all_of(str.begin(), str.end(), lokimq::is_hex_digit<char>);
```