### PR TITLE
Add better deferred reply capabilities to Message

### DIFF
--- a/oxenmq/oxenmq.h
+++ b/oxenmq/oxenmq.h
@@ -1489,15 +1489,29 @@ template <typename... Args>
 void Message::send_back(std::string_view command, Args&&... args) {
     oxenmq.send(conn, command, send_option::optional{!conn.sn()}, std::forward<Args>(args)...);
 }
+template <typename... Args>
+void Message::DeferredSend::back(std::string_view command, Args&&... args) const {
+    oxenmq.send(conn, command, send_option::optional{!conn.sn()}, std::forward<Args>(args)...);
+}
 
 template <typename... Args>
 void Message::send_reply(Args&&... args) {
     assert(!reply_tag.empty());
     oxenmq.send(conn, "REPLY", reply_tag, send_option::optional{!conn.sn()}, std::forward<Args>(args)...);
 }
+template <typename... Args>
+void Message::DeferredSend::reply(Args&&... args) const {
+    assert(!reply_tag.empty());
+    oxenmq.send(conn, "REPLY", reply_tag, send_option::optional{!conn.sn()}, std::forward<Args>(args)...);
+}
 
 template <typename Callback, typename... Args>
 void Message::send_request(std::string_view cmd, Callback&& callback, Args&&... args) {
+    oxenmq.request(conn, cmd, std::forward<Callback>(callback),
+            send_option::optional{!conn.sn()}, std::forward<Args>(args)...);
+}
+template <typename Callback, typename... Args>
+void Message::DeferredSend::request(std::string_view cmd, Callback&& callback, Args&&... args) const {
     oxenmq.request(conn, cmd, std::forward<Callback>(callback),
             send_option::optional{!conn.sn()}, std::forward<Args>(args)...);
 }


### PR DESCRIPTION
This provides an interface for sending a reply to a message later (i.e.
after the Message& itself is no longer valid) by using a new
`send_later()` method of the Message instance that returns an object
that can properly route replies (and can outlive the Message it was
called on).

Intended use is:

    run_this_lambda_later([send=msg.send_later()] {
        send.reply("content");
    });

which is equivalent to:

    run_this_lambda_later([&msg] {
        msg.send_reply("content");
    });

except that it works properly even if the lambda is invoked beyond the
lifetime of `msg`.