### PR TITLE
Add support for std::optional<T> send arguments

### DIFF
--- a/tests/test_commands.cpp
+++ b/tests/test_commands.cpp
@@ -415,13 +415,19 @@ TEST_CASE("data parts", "[send][data_parts]") {
         r.clear();
     }
 
+    std::optional<std::string_view> opt1, opt2;
+    std::optional<std::string> opt3, opt4;
+    opt1 = "o1"sv;
+    opt4 = "o4"s;
     std::vector some_data2{{"a"sv, "b"sv, "\0"sv}};
     client.send(c, "public.hello",
             "hi",
             oxenmq::send_option::data_parts(some_data2.begin(), some_data2.end()),
             "another",
             "string"sv,
-            oxenmq::send_option::data_parts(some_data.begin(), some_data.end()));
+            oxenmq::send_option::data_parts(some_data.begin(), some_data.end()),
+            opt1, opt2, opt3, opt4
+            );
 
     std::vector<std::string> expected;
     expected.push_back("hi");
@@ -429,6 +435,8 @@ TEST_CASE("data parts", "[send][data_parts]") {
     expected.push_back("another");
     expected.push_back("string");
     expected.insert(expected.end(), some_data.begin(), some_data.end());
+    expected.push_back("o1");
+    expected.push_back("o4");
 
     reply_sleep();
     {


### PR DESCRIPTION
If the optional is set it gets applied as if you specified the `T` in
the send(...), if unset it works as if you didn't specify the argument
at all.