### PR TITLE
Add support for listening on a new port after start()

### DIFF
--- a/oxenmq/auth.cpp
+++ b/oxenmq/auth.cpp
@@ -256,14 +256,14 @@ void OxenMQ::process_zap_requests() {
                 LMQ_LOG(error, "Bad ZAP authentication request: invalid auth domain '", auth_domain, "'");
                 status_code = "400";
                 status_text = "Unknown authentication domain: " + std::string{auth_domain};
-            } else if (bind[bind_id].second.curve
+            } else if (bind[bind_id].curve
                     ? !(frames.size() == 7 && view(frames[5]) == "CURVE")
                     : !(frames.size() == 6 && view(frames[5]) == "NULL")) {
                 LMQ_LOG(error, "Bad ZAP authentication request: invalid ",
-                        bind[bind_id].second.curve ? "CURVE" : "NULL", " authentication request");
+                        bind[bind_id].curve ? "CURVE" : "NULL", " authentication request");
                 status_code = "500";
                 status_text = "Invalid authentication request mechanism";
-            } else if (bind[bind_id].second.curve && frames[6].size() != 32) {
+            } else if (bind[bind_id].curve && frames[6].size() != 32) {
                 LMQ_LOG(error, "Bad ZAP authentication request: invalid request pubkey");
                 status_code = "500";
                 status_text = "Invalid public key size for CURVE authentication";
@@ -271,13 +271,13 @@ void OxenMQ::process_zap_requests() {
                 auto ip = view(frames[3]);
                 std::string_view pubkey;
                 bool sn = false;
-                if (bind[bind_id].second.curve) {
+                if (bind[bind_id].curve) {
                     pubkey = view(frames[6]);
                     sn = active_service_nodes.count(std::string{pubkey});
                 }
-                auto auth = bind[bind_id].second.allow(ip, pubkey, sn);
+                auto auth = bind[bind_id].allow(ip, pubkey, sn);
                 auto& user_id = response_vals[4];
-                if (bind[bind_id].second.curve) {
+                if (bind[bind_id].curve) {
                     user_id.reserve(64);
                     to_hex(pubkey.begin(), pubkey.end(), std::back_inserter(user_id));
                 }

--- a/tests/test_connect.cpp
+++ b/tests/test_connect.cpp
@@ -129,6 +129,64 @@ TEST_CASE("plain-text connections", "[plaintext][connect]") {
     }
 }
 
+TEST_CASE("post-start listening", "[connect][listen]") {
+    OxenMQ server{get_logger("S» "), LogLevel::trace};
+    server.add_category("x", AuthLevel::none)
+        .add_request_command("y", [&](Message& m) { m.send_reply("hi", m.data[0]); });
+    server.start();
+    std::atomic<int> listens;
+    auto listen_curve = random_localhost();
+    server.listen_curve(listen_curve, nullptr, [&](bool success) { if (success) listens++; });
+    auto listen_plain = random_localhost();
+    server.listen_plain(listen_plain, nullptr, [&](bool success) { if (success) listens += 10; });
+
+    wait_for([&] { return listens.load() >= 11; });
+    {
+        auto lock = catch_lock();
+        REQUIRE( listens == 11 );
+    }
+
+    // This should fail since we're already listening on it:
+    server.listen_curve(listen_plain, nullptr, [&](bool success) { if (!success) listens++; });
+
+    wait_for([&] { return listens.load() >= 12; });
+    {
+        auto lock = catch_lock();
+        REQUIRE( listens == 12 );
+    }
+
+
+    OxenMQ client{get_logger("C1» "), LogLevel::trace};
+    client.start();
+    std::atomic<int> conns = 0;
+    auto c1 = client.connect_remote(address{listen_curve, server.get_pubkey()},
+            [&](auto) { conns++; },
+            [&](auto, auto why) { auto lock = catch_lock(); UNSCOPED_INFO("connection failed: " << why); });
+    auto c2 = client.connect_remote(address{listen_plain},
+            [&](auto) { conns += 10; },
+            [&](auto, auto why) { auto lock = catch_lock(); UNSCOPED_INFO("connection failed: " << why); });
+
+
+    wait_for([&] { return conns.load() >= 11; });
+    {
+        auto lock = catch_lock();
+        REQUIRE( conns == 11 );
+    }
+
+    std::atomic<int> replies = 0;
+    std::string reply1, reply2;
+    client.request(c1, "x.y", [&](auto success, auto parts) { replies++; for (auto& p : parts) reply1 += p; }, " world");
+    client.request(c2, "x.y", [&](auto success, auto parts) { replies += 10; for (auto& p : parts) reply2 += p; }, " cat");
+
+    wait_for([&] { return replies.load() >= 11; });
+    {
+        auto lock = catch_lock();
+        REQUIRE( replies == 11 );
+        REQUIRE( reply1 == "hi world" );
+        REQUIRE( reply2 == "hi cat" );
+    }
+}
+
 TEST_CASE("unique connection IDs", "[connect][id]") {
     std::string listen = random_localhost();
     OxenMQ server{get_logger("S» "), LogLevel::trace};

--- a/tests/test_connect.cpp
+++ b/tests/test_connect.cpp
@@ -134,7 +134,7 @@ TEST_CASE("post-start listening", "[connect][listen]") {
     server.add_category("x", AuthLevel::none)
         .add_request_command("y", [&](Message& m) { m.send_reply("hi", m.data[0]); });
     server.start();
-    std::atomic<int> listens;
+    std::atomic<int> listens = 0;
     auto listen_curve = random_localhost();
     server.listen_curve(listen_curve, nullptr, [&](bool success) { if (success) listens++; });
     auto listen_plain = random_localhost();


### PR DESCRIPTION
This commit adds support for listening on new ports after startup.  This
will make things easier in storage server, in particular, where we want
to delay listening on public ports until we have an established
connection and initial block status update from oxend.