### PR TITLE
Add support for inproc: connections

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ cmake_minimum_required(VERSION 3.7)
 set(CMAKE_OSX_DEPLOYMENT_TARGET 10.12 CACHE STRING "macOS deployment target (Apple clang only)")
 
 project(liboxenmq
-    VERSION 1.2.6
+    VERSION 1.2.7
     LANGUAGES CXX C)
 
 include(GNUInstallDirs)

--- a/oxenmq/oxenmq.cpp
+++ b/oxenmq/oxenmq.cpp
@@ -262,7 +262,9 @@ void OxenMQ::start() {
 }
 
 void OxenMQ::listen_curve(std::string bind_addr, AllowFunc allow_connection, std::function<void(bool)> on_bind) {
-    if (!allow_connection) allow_connection = [](auto, auto, auto) { return AuthLevel::none; };
+    if (std::string_view{bind_addr}.substr(0, 9) == "inproc://")
+        throw std::logic_error{"inproc:// cannot be used with listen_curve"};
+    if (!allow_connection) allow_connection = [](auto&&...) { return AuthLevel::none; };
     bind_data d{std::move(bind_addr), true, std::move(allow_connection), std::move(on_bind)};
     if (proxy_thread.joinable())
         detail::send_control(get_control_socket(), "BIND", bt_serialize(detail::serialize_object(std::move(d))));
@@ -271,7 +273,9 @@ void OxenMQ::listen_curve(std::string bind_addr, AllowFunc allow_connection, std
 }
 
 void OxenMQ::listen_plain(std::string bind_addr, AllowFunc allow_connection, std::function<void(bool)> on_bind) {
-    if (!allow_connection) allow_connection = [](auto, auto, auto) { return AuthLevel::none; };
+    if (std::string_view{bind_addr}.substr(0, 9) == "inproc://")
+        throw std::logic_error{"inproc:// cannot be used with listen_plain"};
+    if (!allow_connection) allow_connection = [](auto&&...) { return AuthLevel::none; };
     bind_data d{std::move(bind_addr), false, std::move(allow_connection), std::move(on_bind)};
     if (proxy_thread.joinable())
         detail::send_control(get_control_socket(), "BIND", bt_serialize(detail::serialize_object(std::move(d))));

--- a/oxenmq/proxy.cpp
+++ b/oxenmq/proxy.cpp
@@ -411,6 +411,13 @@ void OxenMQ::proxy_loop() {
         saved_umask = umask(STARTUP_UMASK);
 #endif
 
+    {
+        zmq::socket_t inproc_listener{context, zmq::socket_type::router};
+        inproc_listener.bind(SN_ADDR_SELF);
+        inproc_listener_connid = next_conn_id++;
+        connections.emplace_hint(connections.end(), inproc_listener_connid, std::move(inproc_listener));
+    }
+
     for (size_t i = 0; i < bind.size(); i++) {
         if (!proxy_bind(bind[i], i)) {
             LMQ_LOG(warn, "OxenMQ failed to listen on ", bind[i].address);

--- a/oxenmq/worker.cpp
+++ b/oxenmq/worker.cpp
@@ -293,6 +293,11 @@ void OxenMQ::proxy_to_worker(int64_t conn_id, zmq::socket_t& sock, std::vector<z
             return;
         }
         peer = &it->second;
+    } else if (conn_id == inproc_listener_connid) {
+        tmp_peer.auth_level = AuthLevel::admin;
+        tmp_peer.pubkey = pubkey;
+        tmp_peer.service_node = active_service_nodes.count(pubkey);
+        peer = &tmp_peer;
     } else {
         std::tie(tmp_peer.pubkey, tmp_peer.auth_level) = detail::extract_metadata(parts.back());
         tmp_peer.service_node = tmp_peer.pubkey.size() == 32 && active_service_nodes.count(tmp_peer.pubkey);


### PR DESCRIPTION
inproc support is special in zmq: in particular it completely bypasses the auth layer, which causes problems in OxenMQ because we assume that a message will always have auth information (set during initial connection handshake).

This adds an "always-on" inproc listener and adds a new `connect_inproc` method for a caller to establish a connection to it.

It also throws exceptions if you try to `listen_plain` or `listen_curve` on an inproc address, because that won't work for the reasons detailed above.