### PR TITLE
Make {to,from}_{hex/b64/b32} return output iterator

### DIFF
--- a/oxenmq/hex.h
+++ b/oxenmq/hex.h
@@ -62,15 +62,18 @@ static_assert(hex_lut.from_hex('a') == 10 && hex_lut.from_hex('F') == 15 && hex_
 
 } // namespace detail
 
-/// Creates hex digits from a character sequence.
+/// Creates hex digits from a character sequence given by iterators, writes them starting at `out`.
+/// Returns the final value of out (i.e. the iterator positioned just after the last written
+/// hex character).
 template <typename InputIt, typename OutputIt>
-void to_hex(InputIt begin, InputIt end, OutputIt out) {
+OutputIt to_hex(InputIt begin, InputIt end, OutputIt out) {
     static_assert(sizeof(decltype(*begin)) == 1, "to_hex requires chars/bytes");
     for (; begin != end; ++begin) {
         uint8_t c = static_cast<uint8_t>(*begin);
         *out++ = detail::hex_lut.to_hex(c >> 4);
         *out++ = detail::hex_lut.to_hex(c & 0x0f);
     }
+    return out;
 }
 
 /// Creates a string of hex digits from a character sequence iterator pair
@@ -132,9 +135,10 @@ constexpr char from_hex_pair(unsigned char a, unsigned char b) noexcept { return
 /// Converts a sequence of hex digits to bytes.  Undefined behaviour if any characters are not in
 /// [0-9a-fA-F] or if the input sequence length is not even: call `is_hex` first if you need to
 /// check.  It is permitted for the input and output ranges to overlap as long as out is no later
-/// than begin.
+/// than begin.  Returns the final value of out (that is, the iterator positioned just after the
+/// last written character).
 template <typename InputIt, typename OutputIt>
-void from_hex(InputIt begin, InputIt end, OutputIt out) {
+OutputIt from_hex(InputIt begin, InputIt end, OutputIt out) {
     using std::distance;
     assert(is_hex(begin, end));
     while (begin != end) {
@@ -143,6 +147,7 @@ void from_hex(InputIt begin, InputIt end, OutputIt out) {
         *out++ = static_cast<detail::byte_type_t<OutputIt>>(
                 from_hex_pair(static_cast<unsigned char>(a), static_cast<unsigned char>(b)));
     }
+    return out;
 }
 
 /// Converts a sequence of hex digits to a string of bytes and returns it.  Undefined behaviour if

--- a/tests/test_encoding.cpp
+++ b/tests/test_encoding.cpp
@@ -44,6 +44,16 @@ TEST_CASE("hex encoding/decoding", "[encoding][decoding][hex]") {
     std::basic_string_view<std::byte> b{bytes.data(), bytes.size()};
     REQUIRE( oxenmq::to_hex(b) == "ff421234"s );
 
+    // In-place decoding and truncation via to_hex's returned iterator:
+    std::string some_hex = "48656c6c6f";
+    some_hex.erase(oxenmq::from_hex(some_hex.begin(), some_hex.end(), some_hex.begin()), some_hex.end());
+    REQUIRE( some_hex == "Hello" );
+
+    // Test the returned iterator from encoding
+    std::string hellohex;
+    *oxenmq::to_hex(some_hex.begin(), some_hex.end(), std::back_inserter(hellohex))++ = '!';
+    REQUIRE( hellohex == "48656c6c6f!" );
+
     bytes.resize(8);
     bytes[0] = std::byte{'f'}; bytes[1] = std::byte{'f'}; bytes[2] = std::byte{'4'}; bytes[3] = std::byte{'2'};
     bytes[4] = std::byte{'1'}; bytes[5] = std::byte{'2'}; bytes[6] = std::byte{'3'}; bytes[7] = std::byte{'4'};
@@ -98,6 +108,16 @@ TEST_CASE("base32z encoding/decoding", "[encoding][decoding][base32z]") {
     oxenmq::from_base32z(pk_b32z.begin(), pk_b32z.end(), std::back_inserter(pk_again));
     REQUIRE( pk_b32z_again == pk_b32z );
     REQUIRE( pk_again == pk );
+
+    // In-place decoding and truncation via returned iterator:
+    std::string some_b32z = "jb1sa5dx";
+    some_b32z.erase(oxenmq::from_base32z(some_b32z.begin(), some_b32z.end(), some_b32z.begin()), some_b32z.end());
+    REQUIRE( some_b32z == "Hello" );
+
+    // Test the returned iterator from encoding
+    std::string hellob32z;
+    *oxenmq::to_base32z(some_b32z.begin(), some_b32z.end(), std::back_inserter(hellob32z))++ = '!';
+    REQUIRE( hellob32z == "jb1sa5dx!" );
 
     std::vector<std::byte> bytes{{std::byte{0}, std::byte{255}}};
     std::basic_string_view<std::byte> b{bytes.data(), bytes.size()};
@@ -188,6 +208,16 @@ TEST_CASE("base64 encoding/decoding", "[encoding][decoding][base64]") {
     oxenmq::from_base64(pk_b64.begin(), pk_b64.end(), std::back_inserter(pk_again));
     REQUIRE( pk_b64_again == pk_b64 );
     REQUIRE( pk_again == pk );
+
+    // In-place decoding and truncation via returned iterator:
+    std::string some_b64 = "SGVsbG8=";
+    some_b64.erase(oxenmq::from_base64(some_b64.begin(), some_b64.end(), some_b64.begin()), some_b64.end());
+    REQUIRE( some_b64 == "Hello" );
+
+    // Test the returned iterator from encoding
+    std::string hellob64;
+    *oxenmq::to_base64(some_b64.begin(), some_b64.end(), std::back_inserter(hellob64))++ = '!';
+    REQUIRE( hellob64 == "SGVsbG8=!" );
 
     std::vector<std::byte> bytes{{std::byte{0}, std::byte{255}}};
     std::basic_string_view<std::byte> b{bytes.data(), bytes.size()};


### PR DESCRIPTION
Changes the 3-iterator versions of to_hex, from_b32z, etc. to return the
final output iterator, which allows for much easier in-place "from"
conversion without needing a new string by doing something like:
```C++
    std::string data = /* some hex */;
    auto end = oxenmq::from_hex(data.begin(), data.end(), data.begin();
    data.erase(end, data.end());
```
Returning from the "to" converters is a bit less useful but doing it
anyway for consistency (and because it could still have some use, e.g.
if output is into some fixed buffer it lets you determine how much was
written).