### PR TITLE
 Make (and use) iterator approach for encoding/decoding 

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -1,3 +1,6 @@
+
+local apt_get_quiet = 'apt-get -o=Dpkg::Use-Pty=0 -q ';
+
 local debian_pipeline(name, image, arch='amd64', deps='g++ libsodium-dev libzmq3-dev', cmake_extra='', build_type='Release', extra_cmds=[], allow_fail=false) = {
     kind: 'pipeline',
     type: 'docker',
@@ -10,10 +13,12 @@ local debian_pipeline(name, image, arch='amd64', deps='g++ libsodium-dev libzmq3
             image: image,
             [if allow_fail then "failure"]: "ignore",
             commands: [
-                'apt-get update',
-                'apt-get install -y eatmydata',
-                'eatmydata apt-get dist-upgrade -y',
-                'eatmydata apt-get install -y cmake git ninja-build pkg-config ccache ' + deps,
+                'echo "Building on ${DRONE_STAGE_MACHINE}"',
+                'echo "man-db man-db/auto-update boolean false" | debconf-set-selections',
+                apt_get_quiet + 'update',
+                apt_get_quiet + 'install -y eatmydata',
+                'eatmydata ' + apt_get_quiet + 'dist-upgrade -y',
+                'eatmydata ' + apt_get_quiet + 'install -y cmake git ninja-build pkg-config ccache ' + deps,
                 'git submodule update --init --recursive',
                 'mkdir build',
                 'cd build',

--- a/oxenmq/base32z.h
+++ b/oxenmq/base32z.h
@@ -86,22 +86,17 @@ struct base32z_encoder final {
 private:
     InputIt _it, _end;
     static_assert(sizeof(decltype(*_it)) == 1, "base32z_encoder requires chars/bytes input iterator");
-    int bits; // Number of bits held in r; will always be >= 5 until we are at the end.
-    uint_fast16_t r;
+    // Number of bits held in r; will always be >= 5 until we are at the end.
+    int bits{_it != _end ? 8 : 0};
+    // Holds bits of data we've already read, which might belong to current or next chars
+    uint_fast16_t r{bits ? static_cast<unsigned char>(*_it) : 0u};
 public:
     using iterator_category = std::input_iterator_tag;
     using difference_type = std::ptrdiff_t;
     using value_type = char;
     using reference = value_type;
     using pointer = void;
-    base32z_encoder(InputIt begin, InputIt end) : _it{std::move(begin)}, _end{std::move(end)} {
-        if (_it != _end) {
-            bits = 8;
-            r = static_cast<unsigned char>(*_it);
-        } else {
-            bits = 0;
-        }
-    }
+    base32z_encoder(InputIt begin, InputIt end) : _it{std::move(begin)}, _end{std::move(end)} {}
 
     base32z_encoder end() { return {_end, _end}; }
 

--- a/oxenmq/base32z.h
+++ b/oxenmq/base32z.h
@@ -89,7 +89,7 @@ private:
     // Number of bits held in r; will always be >= 5 until we are at the end.
     int bits{_it != _end ? 8 : 0};
     // Holds bits of data we've already read, which might belong to current or next chars
-    uint_fast16_t r{bits ? static_cast<unsigned char>(*_it) : 0u};
+    uint_fast16_t r{bits ? static_cast<unsigned char>(*_it) : (unsigned char)0};
 public:
     using iterator_category = std::input_iterator_tag;
     using difference_type = std::ptrdiff_t;

--- a/oxenmq/base64.h
+++ b/oxenmq/base64.h
@@ -100,7 +100,7 @@ private:
     // Number of bits held in r; will always be >= 6 until we are at the end.
     int bits{_it != _end ? 8 : 0};
     // Holds bits of data we've already read, which might belong to current or next chars
-    uint_fast16_t r{bits ? static_cast<unsigned char>(*_it) : 0u};
+    uint_fast16_t r{bits ? static_cast<unsigned char>(*_it) : (unsigned char)0};
 public:
     using iterator_category = std::input_iterator_tag;
     using difference_type = std::ptrdiff_t;

--- a/oxenmq/base64.h
+++ b/oxenmq/base64.h
@@ -95,23 +95,20 @@ struct base64_encoder final {
 private:
     InputIt _it, _end;
     static_assert(sizeof(decltype(*_it)) == 1, "base64_encoder requires chars/bytes input iterator");
-    int bits; // Number of bits held in r; will always be >= 6 until we are at the end.
+    // How much padding (at most) we can add at the end
     int padding;
-    uint_fast16_t r;
+    // Number of bits held in r; will always be >= 6 until we are at the end.
+    int bits{_it != _end ? 8 : 0};
+    // Holds bits of data we've already read, which might belong to current or next chars
+    uint_fast16_t r{bits ? static_cast<unsigned char>(*_it) : 0u};
 public:
     using iterator_category = std::input_iterator_tag;
     using difference_type = std::ptrdiff_t;
     using value_type = char;
     using reference = value_type;
     using pointer = void;
-    base64_encoder(InputIt begin, InputIt end, bool padded = true) : _it{std::move(begin)}, _end{std::move(end)}, padding{padded} {
-        if (_it != _end) {
-            bits = 8;
-            r = static_cast<unsigned char>(*_it);
-        } else {
-            bits = 0;
-        }
-    }
+    base64_encoder(InputIt begin, InputIt end, bool padded = true)
+        : _it{std::move(begin)}, _end{std::move(end)}, padding{padded} {}
 
     base64_encoder end() { return {_end, _end, false}; }
 

--- a/oxenmq/hex.h
+++ b/oxenmq/hex.h
@@ -67,18 +67,50 @@ inline constexpr size_t to_hex_size(size_t byte_size) { return byte_size * 2; }
 /// Returns the number of bytes required to decode a hex string of the given size.
 inline constexpr size_t from_hex_size(size_t hex_size) { return hex_size / 2; }
 
+/// Iterable object for on-the-fly hex encoding.  Used internally, but also particularly useful when
+/// converting from one encoding to another.
+template <typename InputIt>
+struct hex_encoder final {
+private:
+    InputIt _it, _end;
+    static_assert(sizeof(decltype(*_it)) == 1, "hex_encoder requires chars/bytes input iterator");
+    uint8_t c;
+    bool second_half = false;
+public:
+    using iterator_category = std::input_iterator_tag;
+    using difference_type = std::ptrdiff_t;
+    using value_type = char;
+    using reference = value_type;
+    using pointer = void;
+    hex_encoder(InputIt begin, InputIt end) : _it{std::move(begin)}, _end{std::move(end)} {}
+
+    hex_encoder end() { return {_end, _end}; }
+
+    bool operator==(const hex_encoder& i) { return _it == i._it && second_half == i.second_half; }
+    bool operator!=(const hex_encoder& i) { return !(*this == i); }
+
+    hex_encoder& operator++() {
+        second_half = !second_half;
+        if (!second_half)
+            ++_it;
+        return *this;
+    }
+    hex_encoder operator++(int) { hex_encoder copy{*this}; ++*this; return copy; }
+    char operator*() {
+        return detail::hex_lut.to_hex(second_half
+                ? c & 0x0f
+                : (c = static_cast<uint8_t>(*_it)) >> 4);
+    }
+};
+
 /// Creates hex digits from a character sequence given by iterators, writes them starting at `out`.
 /// Returns the final value of out (i.e. the iterator positioned just after the last written
 /// hex character).
 template <typename InputIt, typename OutputIt>
 OutputIt to_hex(InputIt begin, InputIt end, OutputIt out) {
     static_assert(sizeof(decltype(*begin)) == 1, "to_hex requires chars/bytes");
-    for (; begin != end; ++begin) {
-        uint8_t c = static_cast<uint8_t>(*begin);
-        *out++ = detail::hex_lut.to_hex(c >> 4);
-        *out++ = detail::hex_lut.to_hex(c & 0x0f);
-    }
-    return out;
+    auto it = hex_encoder{begin, end};
+    return std::copy(it, it.end(), out);
 }
 
 /// Creates a string of hex digits from a character sequence iterator pair
@@ -141,6 +173,48 @@ constexpr char from_hex_digit(unsigned char x) noexcept {
 /// Constructs a byte value from a pair of hex digits
 constexpr char from_hex_pair(unsigned char a, unsigned char b) noexcept { return (from_hex_digit(a) << 4) | from_hex_digit(b); }
 
+/// Iterable object for on-the-fly hex decoding.  Used internally but also particularly useful when
+/// converting from one encoding to another.  Undefined behaviour if the given iterator range is not
+/// a valid hex string with even length (i.e. is_hex() should return true).
+template <typename InputIt>
+struct hex_decoder final {
+private:
+    InputIt _it, _end;
+    static_assert(sizeof(decltype(*_it)) == 1, "hex_encoder requires chars/bytes input iterator");
+    char byte;
+public:
+    using iterator_category = std::input_iterator_tag;
+    using difference_type = std::ptrdiff_t;
+    using value_type = char;
+    using reference = value_type;
+    using pointer = void;
+    hex_decoder(InputIt begin, InputIt end) : _it{std::move(begin)}, _end{std::move(end)} {
+        if (_it != _end)
+            load_byte();
+    }
+
+    hex_decoder end() { return {_end, _end}; }
+
+    bool operator==(const hex_decoder& i) { return _it == i._it; }
+    bool operator!=(const hex_decoder& i) { return _it != i._it; }
+
+    hex_decoder& operator++() {
+        if (++_it != _end)
+            load_byte();
+        return *this;
+    }
+    hex_decoder operator++(int) { hex_decoder copy{*this}; ++*this; return copy; }
+    char operator*() const { return byte; }
+
+private:
+    void load_byte() {
+        auto a = *_it;
+        auto b = *++_it;
+        byte = from_hex_pair(static_cast<unsigned char>(a), static_cast<unsigned char>(b));
+    }
+
+};
+
 /// Converts a sequence of hex digits to bytes.  Undefined behaviour if any characters are not in
 /// [0-9a-fA-F] or if the input sequence length is not even: call `is_hex` first if you need to
 /// check.  It is permitted for the input and output ranges to overlap as long as out is no later
@@ -148,14 +222,11 @@ constexpr char from_hex_pair(unsigned char a, unsigned char b) noexcept { return
 /// last written character).
 template <typename InputIt, typename OutputIt>
 OutputIt from_hex(InputIt begin, InputIt end, OutputIt out) {
-    using std::distance;
     assert(is_hex(begin, end));
-    while (begin != end) {
-        auto a = *begin++;
-        auto b = *begin++;
-        *out++ = static_cast<detail::byte_type_t<OutputIt>>(
-                from_hex_pair(static_cast<unsigned char>(a), static_cast<unsigned char>(b)));
-    }
+    auto it = hex_decoder(begin, end);
+    const auto hend = it.end();
+    while (it != hend)
+        *out++ = static_cast<detail::byte_type_t<OutputIt>>(*it++);
     return out;
 }
 

--- a/oxenmq/hex.h
+++ b/oxenmq/hex.h
@@ -74,7 +74,7 @@ struct hex_encoder final {
 private:
     InputIt _it, _end;
     static_assert(sizeof(decltype(*_it)) == 1, "hex_encoder requires chars/bytes input iterator");
-    uint8_t c;
+    uint8_t c = 0;
     bool second_half = false;
 public:
     using iterator_category = std::input_iterator_tag;

--- a/tests/test_encoding.cpp
+++ b/tests/test_encoding.cpp
@@ -139,6 +139,16 @@ TEST_CASE("base32z encoding/decoding", "[encoding][decoding][base32z]") {
     REQUIRE( oxenmq::is_base32z(b32_bytes) );
     REQUIRE( oxenmq::from_base32z(b32_bytes) == "\x00\xff"sv );
 
+    REQUIRE( oxenmq::is_base32z("") );
+    REQUIRE_FALSE( oxenmq::is_base32z("y") );
+    REQUIRE( oxenmq::is_base32z("yy") );
+    REQUIRE_FALSE( oxenmq::is_base32z("yyy") );
+    REQUIRE( oxenmq::is_base32z("yyyy") );
+    REQUIRE( oxenmq::is_base32z("yyyyy") );
+    REQUIRE_FALSE( oxenmq::is_base32z("yyyyyy") );
+    REQUIRE( oxenmq::is_base32z("yyyyyyy") );
+    REQUIRE( oxenmq::is_base32z("yyyyyyyy") );
+
     REQUIRE( oxenmq::to_base32z_size(1) == 2 );
     REQUIRE( oxenmq::to_base32z_size(2) == 4 );
     REQUIRE( oxenmq::to_base32z_size(3) == 5 );
@@ -210,6 +220,7 @@ TEST_CASE("base64 encoding/decoding", "[encoding][decoding][base64]") {
     REQUIRE( oxenmq::is_base64("YWJjZB") ); // not really valid, but we explicitly accept it
 
     REQUIRE_FALSE( oxenmq::is_base64("YWJjZ=") ); // invalid padding (padding can only be 4th or 3rd+4th of a 4-char block)
+    REQUIRE_FALSE( oxenmq::is_base64("YYYYA") ); // invalid: base64 can never be length 4n+1
     REQUIRE_FALSE( oxenmq::is_base64("YWJj=") );
     REQUIRE_FALSE( oxenmq::is_base64("YWJj=A") );
     REQUIRE_FALSE( oxenmq::is_base64("YWJjA===") );

--- a/tests/test_encoding.cpp
+++ b/tests/test_encoding.cpp
@@ -186,6 +186,13 @@ TEST_CASE("base64 encoding/decoding", "[encoding][decoding][base64]") {
     REQUIRE( oxenmq::to_base64("abcde")  == "YWJjZGU=" );
     REQUIRE( oxenmq::to_base64("abcdef") == "YWJjZGVm" );
 
+    REQUIRE( oxenmq::to_base64_unpadded("a")   == "YQ" );
+    REQUIRE( oxenmq::to_base64_unpadded("ab")  == "YWI" );
+    REQUIRE( oxenmq::to_base64_unpadded("abc") == "YWJj" );
+    REQUIRE( oxenmq::to_base64_unpadded("abcd")   == "YWJjZA" );
+    REQUIRE( oxenmq::to_base64_unpadded("abcde")  == "YWJjZGU" );
+    REQUIRE( oxenmq::to_base64_unpadded("abcdef") == "YWJjZGVm" );
+
     REQUIRE( oxenmq::to_base64("\0\0\0\xff"s) == "AAAA/w==" );
     REQUIRE( oxenmq::to_base64("\0\0\0\xff\xff"s) == "AAAA//8=" );
     REQUIRE( oxenmq::to_base64("\0\0\0\xff\xff\xff"s) == "AAAA////" );

--- a/tests/test_encoding.cpp
+++ b/tests/test_encoding.cpp
@@ -60,6 +60,16 @@ TEST_CASE("hex encoding/decoding", "[encoding][decoding][hex]") {
     std::basic_string_view<std::byte> hex_bytes{bytes.data(), bytes.size()};
     REQUIRE( oxenmq::is_hex(hex_bytes) );
     REQUIRE( oxenmq::from_hex(hex_bytes) == "\xff\x42\x12\x34" );
+
+    REQUIRE( oxenmq::to_hex_size(1) == 2 );
+    REQUIRE( oxenmq::to_hex_size(2) == 4 );
+    REQUIRE( oxenmq::to_hex_size(3) == 6 );
+    REQUIRE( oxenmq::to_hex_size(4) == 8 );
+    REQUIRE( oxenmq::to_hex_size(100) == 200 );
+    REQUIRE( oxenmq::from_hex_size(2) == 1 );
+    REQUIRE( oxenmq::from_hex_size(4) == 2 );
+    REQUIRE( oxenmq::from_hex_size(6) == 3 );
+    REQUIRE( oxenmq::from_hex_size(98) == 49 );
 }
 
 TEST_CASE("base32z encoding/decoding", "[encoding][decoding][base32z]") {
@@ -128,6 +138,27 @@ TEST_CASE("base32z encoding/decoding", "[encoding][decoding][base32z]") {
     std::basic_string_view<std::byte> b32_bytes{bytes.data(), bytes.size()};
     REQUIRE( oxenmq::is_base32z(b32_bytes) );
     REQUIRE( oxenmq::from_base32z(b32_bytes) == "\x00\xff"sv );
+
+    REQUIRE( oxenmq::to_base32z_size(1) == 2 );
+    REQUIRE( oxenmq::to_base32z_size(2) == 4 );
+    REQUIRE( oxenmq::to_base32z_size(3) == 5 );
+    REQUIRE( oxenmq::to_base32z_size(4) == 7 );
+    REQUIRE( oxenmq::to_base32z_size(5) == 8 );
+    REQUIRE( oxenmq::to_base32z_size(30) == 48 );
+    REQUIRE( oxenmq::to_base32z_size(31) == 50 );
+    REQUIRE( oxenmq::to_base32z_size(32) == 52 );
+    REQUIRE( oxenmq::to_base32z_size(33) == 53 );
+    REQUIRE( oxenmq::to_base32z_size(100) == 160 );
+    REQUIRE( oxenmq::from_base32z_size(160) == 100 );
+    REQUIRE( oxenmq::from_base32z_size(53) == 33 );
+    REQUIRE( oxenmq::from_base32z_size(52) == 32 );
+    REQUIRE( oxenmq::from_base32z_size(50) == 31 );
+    REQUIRE( oxenmq::from_base32z_size(48) == 30 );
+    REQUIRE( oxenmq::from_base32z_size(8) == 5 );
+    REQUIRE( oxenmq::from_base32z_size(7) == 4 );
+    REQUIRE( oxenmq::from_base32z_size(5) == 3 );
+    REQUIRE( oxenmq::from_base32z_size(4) == 2 );
+    REQUIRE( oxenmq::from_base32z_size(2) == 1 );
 }
 
 TEST_CASE("base64 encoding/decoding", "[encoding][decoding][base64]") {
@@ -228,6 +259,30 @@ TEST_CASE("base64 encoding/decoding", "[encoding][decoding][base64]") {
     std::basic_string_view<std::byte> b64_bytes{bytes.data(), bytes.size()};
     REQUIRE( oxenmq::is_base64(b64_bytes) );
     REQUIRE( oxenmq::from_base64(b64_bytes) == "\xff\x00"sv );
+
+    REQUIRE( oxenmq::to_base64_size(1) == 4 );
+    REQUIRE( oxenmq::to_base64_size(2) == 4 );
+    REQUIRE( oxenmq::to_base64_size(3) == 4 );
+    REQUIRE( oxenmq::to_base64_size(4) == 8 );
+    REQUIRE( oxenmq::to_base64_size(5) == 8 );
+    REQUIRE( oxenmq::to_base64_size(6) == 8 );
+    REQUIRE( oxenmq::to_base64_size(30) == 40 );
+    REQUIRE( oxenmq::to_base64_size(31) == 44 );
+    REQUIRE( oxenmq::to_base64_size(32) == 44 );
+    REQUIRE( oxenmq::to_base64_size(33) == 44 );
+    REQUIRE( oxenmq::to_base64_size(100) == 136 );
+    REQUIRE( oxenmq::from_base64_size(136) == 102 ); // Not symmetric because we don't know the last two are padding
+    REQUIRE( oxenmq::from_base64_size(134) == 100 ); // Unpadded
+    REQUIRE( oxenmq::from_base64_size(44) == 33 );
+    REQUIRE( oxenmq::from_base64_size(43) == 32 );
+    REQUIRE( oxenmq::from_base64_size(42) == 31 );
+    REQUIRE( oxenmq::from_base64_size(40) == 30 );
+    REQUIRE( oxenmq::from_base64_size(8) == 6 );
+    REQUIRE( oxenmq::from_base64_size(7) == 5 );
+    REQUIRE( oxenmq::from_base64_size(6) == 4 );
+    REQUIRE( oxenmq::from_base64_size(4) == 3 );
+    REQUIRE( oxenmq::from_base64_size(3) == 2 );
+    REQUIRE( oxenmq::from_base64_size(2) == 1 );
 }
 
 TEST_CASE("std::byte decoding", "[decoding][hex][base32z][base64]") {


### PR DESCRIPTION
This allows for on-the-fly encoding/decoding, and also allows for on-the-fly transcoding between types without needing intermediate string allocations (see added test cases for examples).

Other changes here:
- includes the size calculations from #51 (though this conflicts with the changes in that PR because I needed to move them).
- starts using the size calculations internally
- makes is_base32z and is_base64 slightly stricter (we no longer consider a trailing "garbage" char to be acceptable).