### PR TITLE
Updates for pyoxenmq 1.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ cmake_minimum_required(VERSION 3.7)
 set(CMAKE_OSX_DEPLOYMENT_TARGET 10.12 CACHE STRING "macOS deployment target (Apple clang only)")
 
 project(liboxenmq
-    VERSION 1.2.7
+    VERSION 1.2.8
     LANGUAGES CXX C)
 
 include(GNUInstallDirs)
@@ -120,12 +120,8 @@ if(WARNINGS_AS_ERRORS)
     target_compile_options(oxenmq PRIVATE -Werror)
 endif()
 
-set_target_properties(oxenmq PROPERTIES
-    CXX_STANDARD 17
-    CXX_STANDARD_REQUIRED ON
-    CXX_EXTENSIONS OFF
-    POSITION_INDEPENDENT_CODE ON
-)
+target_compile_features(oxenmq PUBLIC cxx_std_17)
+set_target_properties(oxenmq PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 function(link_dep_libs target linktype libdirs)
     foreach(lib ${ARGN})

--- a/oxenmq/address.h
+++ b/oxenmq/address.h
@@ -163,9 +163,8 @@ struct address {
 
     /// Returns a QR-code friendly address string.  This returns an all-uppercase version of the
     /// address with "TCP://" or "CURVE://" for the protocol string, and uses upper-case base32z
-    /// encoding for the pubkey (for curve addresses).  For literal IPv6 addresses we replace the
-    /// surround the
-    /// address with $ instead of $
+    /// encoding for the pubkey (for curve addresses).  For literal IPv6 addresses we surround the
+    /// address with $ instead of [...]
     ///
     /// \throws std::logic_error if called on a unix socket address.
     std::string qr_address() const;


### PR DESCRIPTION
Makes some send/connection options more robust to "do nothing" runtime
value, which the Python wrapper needs.

Also found a bunch of doc typos and fixes.

Bump version to 1.2.8 so that new pyoxenmq can build-depend on it.