### PR TITLE
Enable ipv6 support on sockets

### DIFF
--- a/oxenmq/auth.cpp
+++ b/oxenmq/auth.cpp
@@ -267,6 +267,11 @@ void OxenMQ::process_zap_requests() {
                 status_text = "Invalid public key size for CURVE authentication";
             } else {
                 auto ip = view(frames[3]);
+                // If we're in dual stack mode IPv4 address might be IPv4-mapped IPv6 address (e.g.
+                // ::ffff:192.168.0.1); if so, remove the prefix to get a proper IPv4 address:
+                if (ip.size() >= 14 && ip.substr(0, 7) == "::ffff:"sv && ip.find_last_not_of("0123456789."sv) == 6)
+                    ip = ip.substr(7);
+
                 std::string_view pubkey;
                 bool sn = false;
                 if (bind[bind_id].curve) {

--- a/oxenmq/connections.cpp
+++ b/oxenmq/connections.cpp
@@ -40,6 +40,7 @@ void OxenMQ::setup_external_socket(zmq::socket_t& socket) {
     socket.set(zmq::sockopt::reconnect_ivl_max, (int) RECONNECT_INTERVAL_MAX.count());
     socket.set(zmq::sockopt::handshake_ivl, (int) HANDSHAKE_TIME.count());
     socket.set(zmq::sockopt::maxmsgsize, MAX_MSG_SIZE);
+    socket.set(zmq::sockopt::ipv6, 1);
     if (CONN_HEARTBEAT > 0s) {
         socket.set(zmq::sockopt::heartbeat_ivl, (int) CONN_HEARTBEAT.count());
         if (CONN_HEARTBEAT_TIMEOUT > 0s)


### PR DESCRIPTION
Without this you cannot bind or connect to IPv6 addresses because, oddly, libzmq defaults ipv6 to disabled.