### PR TITLE
Rebrand variables LMQ -> OMQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ dictionaries.  See `oxenmq/bt_serialize.h` if you want a bt serializer/deseriali
 Sending a command to a peer is done by using a connection ID, and generally falls into either a
 `send()` method or a `request()` method.
 
-    lmq.send(conn, "category.command", "some data");
-    lmq.request(conn, "category.command", [](bool success, std::vector<std::string> data) {
+    omq.send(conn, "category.command", "some data");
+    omq.request(conn, "category.command", [](bool success, std::vector<std::string> data) {
         if (success) { std::cout << "Remote replied: " << data.at(0) << "\n"; } });
 
 The connection ID generally has two possible values:
@@ -127,13 +127,13 @@ The connection ID generally has two possible values:
     ```C++
     // Send to a service node, establishing a connection if necessary:
     std::string my_sn = ...; // 32-byte pubkey of a known SN
-    lmq.send(my_sn, "sn.explode", "{ \"seconds\": 30 }");
+    omq.send(my_sn, "sn.explode", "{ \"seconds\": 30 }");
 
     // Connect to a remote by address then send it something
-    auto conn = lmq.connect_remote("tcp://127.0.0.1:4567",
+    auto conn = omq.connect_remote("tcp://127.0.0.1:4567",
         [](ConnectionID c) { std::cout << "Connected!\n"; },
         [](ConnectionID c, string_view f) { std::cout << "Connect failed: " << f << "\n" });
-    lmq.request(conn, "rpc.get_height", [](bool s, std::vector<std::string> d) {
+    omq.request(conn, "rpc.get_height", [](bool s, std::vector<std::string> d) {
         if (s && d.size() == 1)
             std::cout << "Current height: " << d[0] << "\n";
         else
@@ -332,7 +332,7 @@ void start_big_task() {
 
     batch.completion(&continue_big_task);
 
-    lmq.batch(std::move(batch));
+    omq.batch(std::move(batch));
     // ... to be continued in `continue_big_task` after all the jobs finish
 
     // Can do other things here, but note that continue_big_task could run
@@ -347,7 +347,7 @@ going to help you hurt yourself like that.
 
 ### Single-job queuing
 
-As a shortcut there is a `lmq.job(...)` method that schedules a single task (with no return value)
+As a shortcut there is a `omq.job(...)` method that schedules a single task (with no return value)
 in the batch job queue.  This is useful when some event requires triggering some other event, but
 you don't need to wait for or collect its result.  (Internally this is just a convenience method
 around creating a single-job, no-completion Batch job).

--- a/oxenmq/auth.cpp
+++ b/oxenmq/auth.cpp
@@ -37,22 +37,22 @@ bool OxenMQ::proxy_check_auth(int64_t conn_id, bool outgoing, const peer_info& p
     std::string reply;
 
     if (!cat_call.first) {
-        LMQ_LOG(warn, "Invalid command '", command, "' sent by remote [", to_hex(peer.pubkey), "]/", peer_address(cmd));
+        OMQ_LOG(warn, "Invalid command '", command, "' sent by remote [", to_hex(peer.pubkey), "]/", peer_address(cmd));
         reply = "UNKNOWNCOMMAND";
     } else if (peer.auth_level < cat_call.first->access.auth) {
-        LMQ_LOG(warn, "Access denied to ", command, " for peer [", to_hex(peer.pubkey), "]/", peer_address(cmd),
+        OMQ_LOG(warn, "Access denied to ", command, " for peer [", to_hex(peer.pubkey), "]/", peer_address(cmd),
                 ": peer auth level ", peer.auth_level, " < ", cat_call.first->access.auth);
         reply = "FORBIDDEN";
     } else if (cat_call.first->access.local_sn && !local_service_node) {
-        LMQ_LOG(warn, "Access denied to ", command, " for peer [", to_hex(peer.pubkey), "]/", peer_address(cmd),
+        OMQ_LOG(warn, "Access denied to ", command, " for peer [", to_hex(peer.pubkey), "]/", peer_address(cmd),
                 ": that command is only available when this OxenMQ is running in service node mode");
         reply = "NOT_A_SERVICE_NODE";
     } else if (cat_call.first->access.remote_sn && !peer.service_node) {
-        LMQ_LOG(warn, "Access denied to ", command, " for peer [", to_hex(peer.pubkey), "]/", peer_address(cmd),
+        OMQ_LOG(warn, "Access denied to ", command, " for peer [", to_hex(peer.pubkey), "]/", peer_address(cmd),
                 ": remote is not recognized as a service node");
         reply = "FORBIDDEN_SN";
     } else if (cat_call.second->second /*is_request*/ && data.empty()) {
-        LMQ_LOG(warn, "Received an invalid request for '", command, "' with no reply tag from remote [",
+        OMQ_LOG(warn, "Received an invalid request for '", command, "' with no reply tag from remote [",
                 to_hex(peer.pubkey), "]/", peer_address(cmd));
         reply = "NO_REPLY_TAG";
     } else {
@@ -75,7 +75,7 @@ bool OxenMQ::proxy_check_auth(int64_t conn_id, bool outgoing, const peer_info& p
         send_message_parts(connections.at(conn_id), msgs);
     } catch (const zmq::error_t& err) {
         /* can't send: possibly already disconnected.  Ignore. */
-        LMQ_LOG(debug, "Couldn't send auth failure message ", reply, " to peer [", to_hex(peer.pubkey), "]/", peer_address(cmd), ": ", err.what());
+        OMQ_LOG(debug, "Couldn't send auth failure message ", reply, " to peer [", to_hex(peer.pubkey), "]/", peer_address(cmd), ": ", err.what());
     }
 
     return false;
@@ -97,7 +97,7 @@ void OxenMQ::proxy_set_active_sns(pubkey_set pubkeys) {
     for (auto it = pubkeys.begin(); it != pubkeys.end(); ) {
         auto& pk = *it;
         if (pk.size() != 32) {
-            LMQ_LOG(warn, "Invalid private key of length ", pk.size(), " (", to_hex(pk), ") passed to set_active_sns");
+            OMQ_LOG(warn, "Invalid private key of length ", pk.size(), " (", to_hex(pk), ") passed to set_active_sns");
             it = pubkeys.erase(it);
             continue;
         }
@@ -106,7 +106,7 @@ void OxenMQ::proxy_set_active_sns(pubkey_set pubkeys) {
         ++it;
     }
     if (added.empty() && active_service_nodes.size() == pubkeys.size()) {
-        LMQ_LOG(debug, "set_active_sns(): new set of SNs is unchanged, skipping update");
+        OMQ_LOG(debug, "set_active_sns(): new set of SNs is unchanged, skipping update");
         return;
     }
     for (const auto& pk : active_service_nodes) {
@@ -141,7 +141,7 @@ void OxenMQ::proxy_update_active_sns(pubkey_set added, pubkey_set removed) {
     for (auto it = removed.begin(); it != removed.end(); ) {
         const auto& pk = *it;
         if (pk.size() != 32) {
-            LMQ_LOG(warn, "Invalid private key of length ", pk.size(), " (", to_hex(pk), ") passed to update_active_sns (removed)");
+            OMQ_LOG(warn, "Invalid private key of length ", pk.size(), " (", to_hex(pk), ") passed to update_active_sns (removed)");
             it = removed.erase(it);
         } else if (!active_service_nodes.count(pk) || added.count(pk) /* added wins if in both */) {
             it = removed.erase(it);
@@ -153,7 +153,7 @@ void OxenMQ::proxy_update_active_sns(pubkey_set added, pubkey_set removed) {
     for (auto it = added.begin(); it != added.end(); ) {
         const auto& pk = *it;
         if (pk.size() != 32) {
-            LMQ_LOG(warn, "Invalid private key of length ", pk.size(), " (", to_hex(pk), ") passed to update_active_sns (added)");
+            OMQ_LOG(warn, "Invalid private key of length ", pk.size(), " (", to_hex(pk), ") passed to update_active_sns (added)");
             it = added.erase(it);
         } else if (active_service_nodes.count(pk)) {
             it = added.erase(it);
@@ -166,7 +166,7 @@ void OxenMQ::proxy_update_active_sns(pubkey_set added, pubkey_set removed) {
 }
 
 void OxenMQ::proxy_update_active_sns_clean(pubkey_set added, pubkey_set removed) {
-    LMQ_LOG(debug, "Updating SN auth status with +", added.size(), "/-", removed.size(), " pubkeys");
+    OMQ_LOG(debug, "Updating SN auth status with +", added.size(), "/-", removed.size(), " pubkeys");
 
     // For anything we remove we want close the connection to the SN (if outgoing), and remove the
     // stored peer_info (incoming or outgoing).
@@ -179,7 +179,7 @@ void OxenMQ::proxy_update_active_sns_clean(pubkey_set added, pubkey_set removed)
             auto conn_id = it->second.conn_id;
             it = peers.erase(it);
             if (outgoing) {
-                LMQ_LOG(debug, "Closing outgoing connection to ", c);
+                OMQ_LOG(debug, "Closing outgoing connection to ", c);
                 proxy_close_connection(conn_id, CLOSE_LINGER);
             }
         }
@@ -207,7 +207,7 @@ void OxenMQ::process_zap_requests() {
             log(LogLevel::trace, __FILE__, __LINE__, o.str());
         } else
 #endif
-            LMQ_LOG(debug, "Processing ZAP authentication request");
+            OMQ_LOG(debug, "Processing ZAP authentication request");
 
         // https://rfc.zeromq.org/spec:27/ZAP/
         //
@@ -240,7 +240,7 @@ void OxenMQ::process_zap_requests() {
         std::string &status_code = response_vals[2], &status_text = response_vals[3];
 
         if (frames.size() < 6 || view(frames[0]) != "1.0") {
-            LMQ_LOG(error, "Bad ZAP authentication request: version != 1.0 or invalid ZAP message parts");
+            OMQ_LOG(error, "Bad ZAP authentication request: version != 1.0 or invalid ZAP message parts");
             status_code = "500";
             status_text = "Internal error: invalid auth request";
         } else {
@@ -251,18 +251,18 @@ void OxenMQ::process_zap_requests() {
             } catch (...) {}
 
             if (bind_id >= bind.size()) {
-                LMQ_LOG(error, "Bad ZAP authentication request: invalid auth domain '", auth_domain, "'");
+                OMQ_LOG(error, "Bad ZAP authentication request: invalid auth domain '", auth_domain, "'");
                 status_code = "400";
                 status_text = "Unknown authentication domain: " + std::string{auth_domain};
             } else if (bind[bind_id].curve
                     ? !(frames.size() == 7 && view(frames[5]) == "CURVE")
                     : !(frames.size() == 6 && view(frames[5]) == "NULL")) {
-                LMQ_LOG(error, "Bad ZAP authentication request: invalid ",
+                OMQ_LOG(error, "Bad ZAP authentication request: invalid ",
                         bind[bind_id].curve ? "CURVE" : "NULL", " authentication request");
                 status_code = "500";
                 status_text = "Invalid authentication request mechanism";
             } else if (bind[bind_id].curve && frames[6].size() != 32) {
-                LMQ_LOG(error, "Bad ZAP authentication request: invalid request pubkey");
+                OMQ_LOG(error, "Bad ZAP authentication request: invalid request pubkey");
                 status_code = "500";
                 status_text = "Invalid public key size for CURVE authentication";
             } else {
@@ -281,14 +281,14 @@ void OxenMQ::process_zap_requests() {
                 }
 
                 if (auth <= AuthLevel::denied || auth > AuthLevel::admin) {
-                    LMQ_LOG(info, "Access denied for incoming ", view(frames[5]), (sn ? " service node" : " client"),
+                    OMQ_LOG(info, "Access denied for incoming ", view(frames[5]), (sn ? " service node" : " client"),
                             " connection from ", !user_id.empty() ? user_id + " at " : ""s, ip,
                             " with initial auth level ", auth);
                     status_code = "400";
                     status_text = "Access denied";
                     user_id.clear();
                 } else {
-                    LMQ_LOG(debug, "Accepted incoming ", view(frames[5]), (sn ? " service node" : " client"),
+                    OMQ_LOG(debug, "Accepted incoming ", view(frames[5]), (sn ? " service node" : " client"),
                             " connection with authentication level ", auth,
                             " from ", !user_id.empty() ? user_id + " at " : ""s, ip);
 
@@ -301,7 +301,7 @@ void OxenMQ::process_zap_requests() {
             }
         }
 
-        LMQ_TRACE("ZAP request result: ", status_code, " ", status_text);
+        OMQ_TRACE("ZAP request result: ", status_code, " ", status_text);
 
         std::vector<zmq::message_t> response;
         response.reserve(response_vals.size());

--- a/oxenmq/message.h
+++ b/oxenmq/message.h
@@ -19,8 +19,8 @@ public:
     std::string remote; ///< Some sort of remote address from which the request came.  Often "IP" for TCP connections and "localhost:UID:GID:PID" for unix socket connections.
 
     /// Constructor
-    Message(OxenMQ& lmq, ConnectionID cid, Access access, std::string remote)
-        : oxenmq{lmq}, conn{std::move(cid)}, access{std::move(access)}, remote{std::move(remote)} {}
+    Message(OxenMQ& omq, ConnectionID cid, Access access, std::string remote)
+        : oxenmq{omq}, conn{std::move(cid)}, access{std::move(access)}, remote{std::move(remote)} {}
 
     // Non-copyable
     Message(const Message&) = delete;
@@ -49,7 +49,7 @@ public:
     void send_reply(Args&&... args);
 
     /// Sends a request back to whomever sent this message.  This is effectively a wrapper around
-    /// lmq.request() that takes care of setting up the recipient arguments.
+    /// omq.request() that takes care of setting up the recipient arguments.
     template <typename ReplyCallback, typename... Args>
     void send_request(std::string_view command, ReplyCallback&& callback, Args&&... args);
 

--- a/oxenmq/oxenmq-internal.h
+++ b/oxenmq/oxenmq-internal.h
@@ -2,15 +2,15 @@
 #include "oxenmq.h"
 
 // Inside some method:
-//     LMQ_LOG(warn, "bad ", 42, " stuff");
+//     OMQ_LOG(warn, "bad ", 42, " stuff");
 //
-#define LMQ_LOG(level, ...) log(LogLevel::level, __FILE__, __LINE__, __VA_ARGS__)
+#define OMQ_LOG(level, ...) log(LogLevel::level, __FILE__, __LINE__, __VA_ARGS__)
 
 #ifndef NDEBUG
-// Same as LMQ_LOG(trace, ...) when not doing a release build; nothing under a release build.
-#  define LMQ_TRACE(...) log(LogLevel::trace, __FILE__, __LINE__, __VA_ARGS__)
+// Same as OMQ_LOG(trace, ...) when not doing a release build; nothing under a release build.
+#  define OMQ_TRACE(...) log(LogLevel::trace, __FILE__, __LINE__, __VA_ARGS__)
 #else
-#  define LMQ_TRACE(...)
+#  define OMQ_TRACE(...)
 #endif
 
 namespace oxenmq {

--- a/oxenmq/oxenmq.cpp
+++ b/oxenmq/oxenmq.cpp
@@ -199,7 +199,7 @@ OxenMQ::OxenMQ(
         sn_lookup{std::move(lookup)}, log_lvl{level}, logger{std::move(logger)}
 {
 
-    LMQ_TRACE("Constructing OxenMQ, id=", object_id, ", this=", this);
+    OMQ_TRACE("Constructing OxenMQ, id=", object_id, ", this=", this);
 
     if (sodium_init() == -1)
         throw std::runtime_error{"libsodium initialization failed"};
@@ -209,7 +209,7 @@ OxenMQ::OxenMQ(
     } else if (pubkey.empty()) {
         if (service_node)
             throw std::invalid_argument("Cannot construct a service node mode OxenMQ without a keypair");
-        LMQ_LOG(debug, "generating x25519 keypair for remote-only OxenMQ instance");
+        OMQ_LOG(debug, "generating x25519 keypair for remote-only OxenMQ instance");
         pubkey.resize(crypto_box_PUBLICKEYBYTES);
         privkey.resize(crypto_box_SECRETKEYBYTES);
         crypto_box_keypair(reinterpret_cast<unsigned char*>(&pubkey[0]), reinterpret_cast<unsigned char*>(&privkey[0]));
@@ -232,13 +232,13 @@ void OxenMQ::start() {
     if (proxy_thread.joinable())
         throw std::logic_error("Cannot call start() multiple times!");
 
-    LMQ_LOG(info, "Initializing OxenMQ ", bind.empty() ? "remote-only" : "listener", " with pubkey ", to_hex(pubkey));
+    OMQ_LOG(info, "Initializing OxenMQ ", bind.empty() ? "remote-only" : "listener", " with pubkey ", to_hex(pubkey));
 
     int zmq_socket_limit = context.get(zmq::ctxopt::socket_limit);
     if (MAX_SOCKETS > 1 && MAX_SOCKETS <= zmq_socket_limit)
         context.set(zmq::ctxopt::max_sockets, MAX_SOCKETS);
     else
-        LMQ_LOG(error, "Not applying OxenMQ::MAX_SOCKETS setting: ", MAX_SOCKETS, " must be in [1, ", zmq_socket_limit, "]");
+        OMQ_LOG(error, "Not applying OxenMQ::MAX_SOCKETS setting: ", MAX_SOCKETS, " must be in [1, ", zmq_socket_limit, "]");
 
     // We bind `command` here so that the `get_control_socket()` below is always connecting to a
     // bound socket, but we do nothing else here: the proxy thread is responsible for everything
@@ -246,10 +246,10 @@ void OxenMQ::start() {
     command.bind(SN_ADDR_COMMAND);
     proxy_thread = std::thread{&OxenMQ::proxy_loop, this};
 
-    LMQ_LOG(debug, "Waiting for proxy thread to get ready...");
+    OMQ_LOG(debug, "Waiting for proxy thread to get ready...");
     auto &control = get_control_socket();
     detail::send_control(control, "START");
-    LMQ_TRACE("Sent START command");
+    OMQ_TRACE("Sent START command");
 
     zmq::message_t ready_msg;
     std::vector<zmq::message_t> parts;
@@ -258,7 +258,7 @@ void OxenMQ::start() {
 
     if (!(parts.size() == 1 && view(parts.front()) == "READY"))
         throw std::runtime_error("Invalid startup message from proxy thread (didn't get expected READY message)");
-    LMQ_LOG(debug, "Proxy thread is ready");
+    OMQ_LOG(debug, "Proxy thread is ready");
 }
 
 void OxenMQ::listen_curve(std::string bind_addr, AllowFunc allow_connection, std::function<void(bool)> on_bind) {
@@ -286,7 +286,7 @@ void OxenMQ::listen_plain(std::string bind_addr, AllowFunc allow_connection, std
 
 std::pair<OxenMQ::category*, const std::pair<OxenMQ::CommandCallback, bool>*> OxenMQ::get_command(std::string& command) {
     if (command.size() > MAX_CATEGORY_LENGTH + 1 + MAX_COMMAND_LENGTH) {
-        LMQ_LOG(warn, "Invalid command '", command, "': command too long");
+        OMQ_LOG(warn, "Invalid command '", command, "': command too long");
         return {};
     }
 
@@ -298,7 +298,7 @@ std::pair<OxenMQ::category*, const std::pair<OxenMQ::CommandCallback, bool>*> Ox
 
     auto dot = command.find('.');
     if (dot == 0 || dot == std::string::npos) {
-        LMQ_LOG(warn, "Invalid command '", command, "': expected <category>.<command>");
+        OMQ_LOG(warn, "Invalid command '", command, "': expected <category>.<command>");
         return {};
     }
     std::string catname = command.substr(0, dot);
@@ -306,14 +306,14 @@ std::pair<OxenMQ::category*, const std::pair<OxenMQ::CommandCallback, bool>*> Ox
 
     auto catit = categories.find(catname);
     if (catit == categories.end()) {
-        LMQ_LOG(warn, "Invalid command category '", catname, "'");
+        OMQ_LOG(warn, "Invalid command category '", catname, "'");
         return {};
     }
 
     const auto& category = catit->second;
     auto callback_it = category.commands.find(cmd);
     if (callback_it == category.commands.end()) {
-        LMQ_LOG(warn, "Invalid command '", command, "'");
+        OMQ_LOG(warn, "Invalid command '", command, "'");
         return {};
     }
 
@@ -416,10 +416,10 @@ OxenMQ::~OxenMQ() {
         return;
     }
 
-    LMQ_LOG(info, "OxenMQ shutting down proxy thread");
+    OMQ_LOG(info, "OxenMQ shutting down proxy thread");
     detail::send_control(get_control_socket(), "QUIT");
     proxy_thread.join();
-    LMQ_LOG(info, "OxenMQ proxy thread has stopped");
+    OMQ_LOG(info, "OxenMQ proxy thread has stopped");
 }
 
 std::ostream &operator<<(std::ostream &os, LogLevel lvl) {

--- a/oxenmq/oxenmq.h
+++ b/oxenmq/oxenmq.h
@@ -680,7 +680,7 @@ private:
         Access access;
         std::string remote;
 
-        // Normal ctor for an actual lmq command being processed
+        // Normal ctor for an actual omq command being processed
         pending_command(category& cat, std::string command, std::vector<zmq::message_t> data_parts,
                 const std::pair<CommandCallback, bool>* callback, ConnectionID conn, Access access, std::string remote)
             : cat{cat}, command{std::move(command)}, data_parts{std::move(data_parts)},
@@ -963,7 +963,7 @@ public:
      *   another `set_active_sns()` or a `update_active_sns()` call).  It *is* possible to make the
      *   initial call after calling `start()`, but that creates a window during which incoming
      *   remote SN connections will be erroneously treated as non-SN connections.
-     * - If this LMQ instance should accept incoming connections, set up any listening ports via
+     * - If this OMQ instance should accept incoming connections, set up any listening ports via
      *   `listen_curve()` and/or `listen_plain()`.
      */
     void start();
@@ -1147,13 +1147,13 @@ public:
      * Example:
      *
      *     // Send to a SN, connecting to it if we aren't already connected:
-     *     lmq.send(pubkey, "hello.world", "abc", send_option::hint("tcp://localhost:1234"), "def");
+     *     omq.send(pubkey, "hello.world", "abc", send_option::hint("tcp://localhost:1234"), "def");
      *
      *     // Start connecting to a remote and immediately queue a message for it
-     *     auto conn = lmq.connect_remote("tcp://127.0.0.1:1234",
+     *     auto conn = omq.connect_remote("tcp://127.0.0.1:1234",
      *         [](ConnectionID) { std::cout << "connected\n"; },
      *         [](ConnectionID, string_view why) { std::cout << "connection failed: " << why << \n"; });
-     *     lmq.send(conn, "hello.world", "abc", "def");
+     *     omq.send(conn, "hello.world", "abc", "def");
      *
      * Both of these send the command `hello.world` to the given pubkey, containing additional
      * message parts "abc" and "def".  In the first case, if not currently connected, the given
@@ -1204,7 +1204,7 @@ public:
      * @param category - the category name that should handle the request for the purposes of
      * scheduling the job.  The category must have been added using add_category().  The category
      * can be an actual category with added commands, in which case the injected tasks are queued
-     * along with LMQ requests for that category, or can have no commands to set up a distinct
+     * along with OMQ requests for that category, or can have no commands to set up a distinct
      * category for the injected jobs.
      *
      * @param command - a command name; this is mainly used for debugging and does not need to
@@ -1326,32 +1326,32 @@ public:
 ///
 /// This allows simplifying:
 ///
-/// lmq.add_category("foo", ...);
-/// lmq.add_command("foo", "a", ...);
-/// lmq.add_command("foo", "b", ...);
-/// lmq.add_request_command("foo", "c", ...);
+/// omq.add_category("foo", ...);
+/// omq.add_command("foo", "a", ...);
+/// omq.add_command("foo", "b", ...);
+/// omq.add_request_command("foo", "c", ...);
 ///
 /// to:
 ///
-/// lmq.add_category("foo", ...)
+/// omq.add_category("foo", ...)
 ///     .add_command("a", ...)
 ///     .add_command("b", ...)
 ///     .add_request_command("b", ...)
 ///     ;
 class CatHelper {
-    OxenMQ& lmq;
+    OxenMQ& omq;
     std::string cat;
 
 public:
-    CatHelper(OxenMQ& lmq, std::string cat) : lmq{lmq}, cat{std::move(cat)} {}
+    CatHelper(OxenMQ& omq, std::string cat) : omq{omq}, cat{std::move(cat)} {}
 
     CatHelper& add_command(std::string name, OxenMQ::CommandCallback callback) {
-        lmq.add_command(cat, std::move(name), std::move(callback));
+        omq.add_command(cat, std::move(name), std::move(callback));
         return *this;
     }
 
     CatHelper& add_request_command(std::string name, OxenMQ::CommandCallback callback) {
-        lmq.add_request_command(cat, std::move(name), std::move(callback));
+        omq.add_request_command(cat, std::move(name), std::move(callback));
         return *this;
     }
 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 add_subdirectory(Catch2)
 
-set(LMQ_TEST_SRC
+add_executable(tests
     main.cpp
     test_address.cpp
     test_batch.cpp
@@ -14,9 +14,7 @@ set(LMQ_TEST_SRC
     test_requests.cpp
     test_tagged_threads.cpp
     test_timer.cpp
-    )
-
-add_executable(tests ${LMQ_TEST_SRC})
+)
 
 find_package(Threads)
 

--- a/tests/test_connect.cpp
+++ b/tests/test_connect.cpp
@@ -244,7 +244,7 @@ TEST_CASE("unique connection IDs", "[connect][id]") {
 
 
 TEST_CASE("SN disconnections", "[connect][disconnect]") {
-    std::vector<std::unique_ptr<OxenMQ>> lmq;
+    std::vector<std::unique_ptr<OxenMQ>> omq;
     std::vector<std::string> pubkey, privkey;
     std::unordered_map<std::string, std::string> conn;
     REQUIRE(sodium_init() != -1);
@@ -258,13 +258,13 @@ TEST_CASE("SN disconnections", "[connect][disconnect]") {
     }
     std::atomic<int> his{0};
     for (int i = 0; i < pubkey.size(); i++) {
-        lmq.push_back(std::make_unique<OxenMQ>(
+        omq.push_back(std::make_unique<OxenMQ>(
             pubkey[i], privkey[i], true,
             [conn](auto pk) { auto it = conn.find((std::string) pk); if (it != conn.end()) return it->second; return ""s; },
             get_logger("S" + std::to_string(i) + "» "),
             LogLevel::trace
         ));
-        auto& server = *lmq.back();
+        auto& server = *omq.back();
 
         server.listen_curve(conn[pubkey[i]]);
         server.add_category("sn", Access{AuthLevel::none, true})
@@ -273,12 +273,12 @@ TEST_CASE("SN disconnections", "[connect][disconnect]") {
         server.start();
     }
 
-    lmq[0]->send(pubkey[1], "sn.hi");
-    lmq[0]->send(pubkey[2], "sn.hi");
-    lmq[2]->send(pubkey[0], "sn.hi");
-    lmq[2]->send(pubkey[1], "sn.hi");
-    lmq[1]->send(pubkey[0], "BYE");
-    lmq[0]->send(pubkey[2], "sn.hi");
+    omq[0]->send(pubkey[1], "sn.hi");
+    omq[0]->send(pubkey[2], "sn.hi");
+    omq[2]->send(pubkey[0], "sn.hi");
+    omq[2]->send(pubkey[1], "sn.hi");
+    omq[1]->send(pubkey[0], "BYE");
+    omq[0]->send(pubkey[2], "sn.hi");
     std::this_thread::sleep_for(50ms * TIME_DILATION);
 
     auto lock = catch_lock();


### PR DESCRIPTION
Various things still were using the lmq (or LMQ) names; change them all
to omq/OMQ.