### PR TITLE
Optimizations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,8 +140,12 @@ if(WARNINGS_AS_ERRORS)
     target_compile_options(oxenmq PRIVATE -Werror)
 endif()
 
-target_compile_features(oxenmq PUBLIC cxx_std_17)
-set_target_properties(oxenmq PROPERTIES POSITION_INDEPENDENT_CODE ON)
+set_target_properties(oxenmq PROPERTIES
+    POSITION_INDEPENDENT_CODE ON
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON
+    CXX_EXTENSIONS OFF
+)
 
 function(link_dep_libs target linktype libdirs)
     foreach(lib ${ARGN})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ cmake_minimum_required(VERSION 3.7)
 set(CMAKE_OSX_DEPLOYMENT_TARGET 10.12 CACHE STRING "macOS deployment target (Apple clang only)")
 
 project(liboxenmq
-    VERSION 1.2.11
+    VERSION 1.2.12
     LANGUAGES CXX C)
 
 include(GNUInstallDirs)

--- a/oxenmq/jobs.cpp
+++ b/oxenmq/jobs.cpp
@@ -5,7 +5,6 @@
 namespace oxenmq {
 
 void OxenMQ::proxy_batch(detail::Batch* batch) {
-    batches.insert(batch);
     const auto [jobs, tagged_threads] = batch->size();
     OMQ_TRACE("proxy queuing batch job with ", jobs, " jobs", tagged_threads ? " (job uses tagged thread(s))" : "");
     if (!tagged_threads) {
@@ -37,7 +36,6 @@ void OxenMQ::job(std::function<void()> f, std::optional<TaggedThreadID> thread) 
 void OxenMQ::proxy_schedule_reply_job(std::function<void()> f) {
     auto* j = new Job(std::move(f));
     reply_jobs.emplace_back(static_cast<detail::Batch*>(j), 0);
-    batches.insert(j);
     proxy_skip_one_poll = true;
 }
 
@@ -113,7 +111,6 @@ void OxenMQ::_queue_timer_job(int timer_id) {
     } else {
         b = new Job(func, thread);
     }
-    batches.insert(b);
     OMQ_TRACE("b: ", b->size().first, ", ", b->size().second, "; thread = ", thread);
     assert(b->size() == std::make_pair(size_t{1}, thread > 0));
     auto& queue = thread > 0

--- a/oxenmq/jobs.cpp
+++ b/oxenmq/jobs.cpp
@@ -170,8 +170,9 @@ TaggedThreadID OxenMQ::add_tagged_thread(std::string name, std::function<void()>
     auto& [run, busy, queue] = tagged_workers.emplace_back();
     busy = false;
     run.worker_id = tagged_workers.size(); // We want index + 1 (b/c 0 is used for non-tagged jobs)
-    run.worker_routing_id = "t" + std::to_string(run.worker_id);
-    OMQ_TRACE("Created new tagged thread ", name, " with routing id ", run.worker_routing_id);
+    run.worker_routing_name = "t" + std::to_string(run.worker_id);
+    run.worker_routing_id = "t" + std::string{reinterpret_cast<const char*>(&run.worker_id), sizeof(run.worker_id)};
+    OMQ_TRACE("Created new tagged thread ", name, " with routing id ", run.worker_routing_name);
 
     run.worker_thread = std::thread{&OxenMQ::worker_thread, this, run.worker_id, name, std::move(start)};
 

--- a/oxenmq/oxenmq.h
+++ b/oxenmq/oxenmq.h
@@ -744,8 +744,9 @@ private:
 
         // These belong to the proxy thread and must not be accessed by a worker:
         std::thread worker_thread;
-        size_t worker_id; // The index in `workers` (0-n) or index+1 in `tagged_workers` (1-n)
-        std::string worker_routing_id; // "w123" where 123 == worker_id; "n123" for tagged threads.
+        uint32_t worker_id; // The index in `workers` (0-n) or index+1 in `tagged_workers` (1-n)
+        std::string worker_routing_id; // "wXXXX" where XXXX is the raw bytes of worker_id, or tXXXX for tagged threads.
+        std::string worker_routing_name; // "w123" or "t123" -- human readable version of worker_routing_id
 
         /// Loads the run info with an incoming command
         run_info& load(category* cat, std::string command, ConnectionID conn, Access access, std::string remote,

--- a/oxenmq/oxenmq.h
+++ b/oxenmq/oxenmq.h
@@ -106,6 +106,7 @@ private:
     explicit constexpr TaggedThreadID(int id) : _id{id} {}
     friend class OxenMQ;
     template <typename R> friend class Batch;
+    friend class Job;
 };
 
 /// Opaque handler for a timer constructed by add_timer(...).  Safe (and cheap) to copy.  The only

--- a/oxenmq/oxenmq.h
+++ b/oxenmq/oxenmq.h
@@ -579,13 +579,14 @@ private:
     /// Individual batch jobs waiting to run; .second is the 0-n batch number or -1 for the
     /// completion job
     using batch_job = std::pair<detail::Batch*, int>;
-    std::queue<batch_job> batch_jobs, reply_jobs;
+    using batch_queue = std::deque<batch_job>;
+    batch_queue batch_jobs, reply_jobs;
     int batch_jobs_active = 0;
     int reply_jobs_active = 0;
     int batch_jobs_reserved = -1;
     int reply_jobs_reserved = -1;
     /// Runs any queued batch jobs
-    void proxy_run_batch_jobs(std::queue<batch_job>& jobs, int reserved, int& active, bool reply);
+    void proxy_run_batch_jobs(batch_queue& jobs, int reserved, int& active, bool reply);
 
     /// BATCH command.  Called with a Batch<R> (see oxenmq/batch.h) object pointer for the proxy to
     /// take over and queue batch jobs.
@@ -768,7 +769,7 @@ private:
     /// Workers that are reserved for tagged thread tasks (as created with add_tagged_thread).  The
     /// queue here is similar to worker_jobs, but contains only the tagged thread's jobs.  The bool
     /// is whether the worker is currently busy (true) or available (false).
-    std::vector<std::tuple<run_info, bool, std::queue<batch_job>>> tagged_workers;
+    std::vector<std::tuple<run_info, bool, batch_queue>> tagged_workers;
 
 public:
     /**

--- a/oxenmq/oxenmq.h
+++ b/oxenmq/oxenmq.h
@@ -484,7 +484,9 @@ private:
 
     void proxy_conn_cleanup();
 
-    void proxy_worker_message(std::vector<zmq::message_t>& parts);
+    using control_message_array = std::array<zmq::message_t, 3>;
+
+    void proxy_worker_message(control_message_array& parts, size_t len);
 
     void proxy_process_queue();
 
@@ -608,7 +610,7 @@ private:
     void process_zap_requests();
 
     /// Handles a control message from some outer thread to the proxy
-    void proxy_control_message(std::vector<zmq::message_t>& parts);
+    void proxy_control_message(control_message_array& parts, size_t len);
 
     /// Closing any idle connections that have outlived their idle time.  Note that this only
     /// affects outgoing connections; incomings connections are the responsibility of the other end.

--- a/oxenmq/oxenmq.h
+++ b/oxenmq/oxenmq.h
@@ -576,8 +576,6 @@ private:
     /// weaker (i.e. it cannot reconnect to the SN if the connection is no longer open).
     void proxy_reply(oxenc::bt_dict_consumer data);
 
-    /// Currently active batch/reply jobs; this is the container that owns the Batch instances
-    std::unordered_set<detail::Batch*> batches;
     /// Individual batch jobs waiting to run; .second is the 0-n batch number or -1 for the
     /// completion job
     using batch_job = std::pair<detail::Batch*, int>;

--- a/oxenmq/oxenmq.h
+++ b/oxenmq/oxenmq.h
@@ -45,6 +45,7 @@
 #include <cassert>
 #include <cstdint>
 #include <future>
+#include <variant>
 #include "zmq.hpp"
 #include "address.h"
 #include <oxenc/bt_serialize.h>

--- a/oxenmq/oxenmq.h
+++ b/oxenmq/oxenmq.h
@@ -456,8 +456,9 @@ private:
     /// Router socket to reach internal worker threads from proxy
     zmq::socket_t workers_socket{context, zmq::socket_type::router};
 
-    /// indices of idle, active workers
+    /// indices of idle, active workers; note that this vector is usually oversized
     std::vector<unsigned int> idle_workers;
+    size_t idle_worker_count = 0; // Actual # elements of idle_workers in use
 
     /// Maximum number of general task workers, specified by set_general_threads()
     int general_workers = std::max<int>(1, std::thread::hardware_concurrency());
@@ -469,7 +470,7 @@ private:
     int max_workers;
 
     /// Number of active workers
-    int active_workers() const { return workers.size() - idle_workers.size(); }
+    int active_workers() const { return workers.size() - idle_worker_count; }
 
     /// Worker thread loop.  Tagged and start are provided for a tagged worker thread.
     void worker_thread(unsigned int index, std::optional<std::string> tagged = std::nullopt, std::function<void()> start = nullptr);

--- a/oxenmq/proxy.cpp
+++ b/oxenmq/proxy.cpp
@@ -482,7 +482,7 @@ void OxenMQ::proxy_loop_init() {
         }
 
         for (auto&w : tagged_workers) {
-            OMQ_LOG(debug, "Telling tagged thread worker ", std::get<run_info>(w).worker_routing_id, " to finish startup");
+            OMQ_LOG(debug, "Telling tagged thread worker ", std::get<run_info>(w).worker_routing_name, " to finish startup");
             route_control(workers_socket, std::get<run_info>(w).worker_routing_id, "START");
         }
     }

--- a/oxenmq/proxy.cpp
+++ b/oxenmq/proxy.cpp
@@ -731,7 +731,7 @@ void OxenMQ::proxy_process_queue() {
         if (!busy && !queue.empty()) {
             busy = true;
             proxy_run_worker(run.load(std::move(queue.front()), false, run.worker_id));
-            queue.pop();
+            queue.pop_front();
         }
     }
 

--- a/oxenmq/proxy.cpp
+++ b/oxenmq/proxy.cpp
@@ -325,9 +325,9 @@ void OxenMQ::proxy_control_message(OxenMQ::control_message_array& parts, size_t 
             // close workers as they come back to READY status, and then close external
             // connections once all workers are done.
             max_workers = 0;
-            for (const auto &route : idle_workers)
-                route_control(workers_socket, workers[route].worker_routing_id, "QUIT");
-            idle_workers.clear();
+            for (size_t i = 0; i < idle_worker_count; i++)
+                route_control(workers_socket, workers[idle_workers[i]].worker_routing_id, "QUIT");
+            idle_worker_count = 0;
             for (auto& [run, busy, queue] : tagged_workers)
                 if (!busy)
                     route_control(workers_socket, run.worker_routing_id, "QUIT");
@@ -404,6 +404,7 @@ void OxenMQ::proxy_loop_init() {
     }
 
     workers.reserve(max_workers);
+    idle_workers.resize(max_workers);
     if (!workers.empty())
         throw std::logic_error("Internal error: proxy thread started with active worker threads");
 

--- a/oxenmq/worker.cpp
+++ b/oxenmq/worker.cpp
@@ -177,10 +177,10 @@ OxenMQ::run_info& OxenMQ::get_idle_worker() {
     return workers[id];
 }
 
-void OxenMQ::proxy_worker_message(std::vector<zmq::message_t>& parts) {
+void OxenMQ::proxy_worker_message(OxenMQ::control_message_array& parts, size_t len) {
     // Process messages sent by workers
-    if (parts.size() != 2) {
-        OMQ_LOG(error, "Received send invalid ", parts.size(), "-part message");
+    if (len != 2) {
+        OMQ_LOG(error, "Received send invalid ", len, "-part message");
         return;
     }
     auto route = view(parts[0]), cmd = view(parts[1]);

--- a/oxenmq/worker.cpp
+++ b/oxenmq/worker.cpp
@@ -48,10 +48,11 @@ bool worker_wait_for(OxenMQ& omq, zmq::socket_t& sock, std::vector<zmq::message_
 }
 
 void OxenMQ::worker_thread(unsigned int index, std::optional<std::string> tagged, std::function<void()> start) {
-    std::string routing_id = (tagged ? "t" : "w") + std::to_string(index); // for routing
-    std::string_view worker_id{tagged ? *tagged : routing_id};              // for debug
+    std::string routing_id = (tagged ? "t" : "w") +
+        std::string(reinterpret_cast<const char*>(&index), sizeof(index)); // for routing
+    std::string worker_id{tagged ? *tagged : "w" + std::to_string(index)}; // for debug
 
-    [[maybe_unused]] std::string thread_name = tagged.value_or("omq-" + routing_id);
+    [[maybe_unused]] std::string thread_name = tagged.value_or("omq-" + worker_id);
 #if defined(__linux__) || defined(__sun) || defined(__MINGW32__)
     if (thread_name.size() > 15) thread_name.resize(15);
     pthread_setname_np(pthread_self(), thread_name.c_str());
@@ -167,7 +168,8 @@ OxenMQ::run_info& OxenMQ::get_idle_worker() {
         workers.emplace_back();
         auto& r = workers.back();
         r.worker_id = id;
-        r.worker_routing_id = "w" + std::to_string(id);
+        r.worker_routing_id = "w" + std::string(reinterpret_cast<const char*>(&id), sizeof(id));
+        r.worker_routing_name = "w" + std::to_string(id);
         return r;
     }
     size_t id = idle_workers.back();
@@ -182,18 +184,17 @@ void OxenMQ::proxy_worker_message(std::vector<zmq::message_t>& parts) {
         return;
     }
     auto route = view(parts[0]), cmd = view(parts[1]);
-    OMQ_TRACE("worker message from ", route);
-    assert(route.size() >= 2 && (route[0] == 'w' || route[0] == 't') && route[1] >= '0' && route[1] <= '9');
+    if (route.size() != 5 || (route[0] != 'w' && route[0] != 't')) {
+        OMQ_LOG(error, "Received malformed worker id in worker message; unable to process worker command");
+        return;
+    }
     bool tagged_worker = route[0] == 't';
-    std::string_view worker_id_str{&route[1], route.size()-1}; // Chop off the leading "w" (or "t")
-    unsigned int worker_id = oxenc::detail::extract_unsigned(worker_id_str);
-    if (!worker_id_str.empty() /* didn't consume everything */ ||
-            (tagged_worker
-                ? 0 == worker_id || worker_id > tagged_workers.size() // tagged worker ids are indexed from 1 to N (0 means untagged)
-                : worker_id >= workers.size() // regular worker ids are indexed from 0 to N-1
-            )
-    ) {
-        OMQ_LOG(error, "Worker id '", route, "' is invalid, unable to process worker command");
+    uint32_t worker_id;
+    std::memcpy(&worker_id, route.data() + 1, 4);
+    if (tagged_worker
+            ? 0 == worker_id || worker_id > tagged_workers.size() // tagged worker ids are indexed from 1 to N (0 means untagged)
+            : worker_id >= workers.size()) { // regular worker ids are indexed from 0 to N-1
+        OMQ_LOG(error, "Received invalid worker id w" + std::to_string(worker_id) + " in worker message; unable to process worker command");
         return;
     }
 
@@ -380,7 +381,7 @@ void OxenMQ::proxy_to_worker(int64_t conn_id, zmq::socket_t& sock, std::vector<z
         peer->activity(); // outgoing connection activity, pump the activity timer
 
     OMQ_TRACE("Forwarding incoming ", run.command, " from ", run.conn, " @ ", peer_address(parts[command_part_index]),
-            " to worker ", run.worker_routing_id);
+            " to worker ", run.worker_routing_name);
 
     proxy_run_worker(run);
     category.active_threads++;
@@ -411,7 +412,7 @@ void OxenMQ::proxy_inject_task(injected_task task) {
     }
 
     auto& run = get_idle_worker();
-    OMQ_TRACE("Forwarding incoming injected task ", task.command, " from ", task.remote, " to worker ", run.worker_routing_id);
+    OMQ_TRACE("Forwarding incoming injected task ", task.command, " from ", task.remote, " to worker ", run.worker_routing_name);
     run.load(&category, std::move(task.command), std::move(task.remote), std::move(task.callback));
 
     proxy_run_worker(run);

--- a/oxenmq/worker.cpp
+++ b/oxenmq/worker.cpp
@@ -233,11 +233,11 @@ void OxenMQ::proxy_worker_message(std::vector<zmq::message_t>& parts) {
                     } else {
                         auto& jobs =
                             thread > 0
-                            ? std::get<std::queue<batch_job>>(tagged_workers[thread - 1]) // run in tagged thread
+                            ? std::get<batch_queue>(tagged_workers[thread - 1]) // run in tagged thread
                             : run.is_reply_job
                               ? reply_jobs
                               : batch_jobs;
-                        jobs.emplace(batch, -1);
+                        jobs.emplace_back(batch, -1);
                     }
                 } else if (state == detail::BatchState::done) {
                     // No completion job

--- a/oxenmq/worker.cpp
+++ b/oxenmq/worker.cpp
@@ -247,7 +247,6 @@ void OxenMQ::proxy_worker_message(OxenMQ::control_message_array& parts, size_t l
 
             if (clear_job) {
                 delete batch;
-                run.to_run = static_cast<detail::Batch*>(nullptr);
             }
         } else {
             assert(run.cat->active_threads > 0);

--- a/oxenmq/worker.cpp
+++ b/oxenmq/worker.cpp
@@ -247,7 +247,6 @@ void OxenMQ::proxy_worker_message(std::vector<zmq::message_t>& parts) {
             }
 
             if (clear_job) {
-                batches.erase(batch);
                 delete batch;
                 run.to_run = static_cast<detail::Batch*>(nullptr);
             }


### PR DESCRIPTION
This currently allows approximately 30% better throughput on tiny jobs (when the proxy thread is the bottleneck).

Broken down commit-by-commit.

Testing using:
```C++
#include <oxenmq/oxenmq.h>
#include <chrono>

std::atomic<int64_t> did{0};

using namespace std::literals;

int main() {

    constexpr auto target_jobs = 2'000'000;

    oxenmq::OxenMQ omq;
    omq.set_general_threads(4);
    omq.start();

    auto start = std::chrono::system_clock::now();
    while (true) {
        int64_t target = did + 1000;
        for (int i = 0; i < 1000; i++) {
            omq.job([] { did++; });
        }
        while (did < target)
            std::this_thread::sleep_for(1ms);
        if (target >= target_jobs)
            break;
    }

    std::chrono::duration<double> elapsed{std::chrono::system_clock::now() - start};
    std::cout << "Elapsed: " << elapsed.count() << " for " << target_jobs << " jobs (" << (target_jobs / elapsed.count()) << "/s)\n";
}
```