### PR TITLE
Fix zmq socket limit setting

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -103,6 +103,7 @@ local full_llvm(version) = debian_pipeline(
         commands: [
           'mkdir build',
           'cd build',
+          'ulimit -n 1024',  // Because macOS has a stupid tiny default ulimit
           'cmake .. -G Ninja -DCMAKE_CXX_FLAGS=-fcolor-diagnostics -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER_LAUNCHER=ccache',
           'ninja -v',
           './tests/tests --use-colour yes',

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ cmake_minimum_required(VERSION 3.7)
 set(CMAKE_OSX_DEPLOYMENT_TARGET 10.12 CACHE STRING "macOS deployment target (Apple clang only)")
 
 project(liboxenmq
-    VERSION 1.2.12
+    VERSION 1.2.13
     LANGUAGES CXX C)
 
 include(GNUInstallDirs)

--- a/oxenmq/connections.cpp
+++ b/oxenmq/connections.cpp
@@ -1,6 +1,7 @@
 #include "oxenmq.h"
 #include "oxenmq-internal.h"
 #include <oxenc/hex.h>
+#include <optional>
 
 namespace oxenmq {
 
@@ -156,10 +157,11 @@ OxenMQ::proxy_connect_sn(std::string_view remote, std::string_view connect_hint,
     }
 
     OMQ_LOG(debug, oxenc::to_hex(pubkey), " (me) connecting to ", addr, " to reach ", oxenc::to_hex(remote));
-    zmq::socket_t socket{context, zmq::socket_type::dealer};
-    setup_outgoing_socket(socket, remote, use_ephemeral_routing_id);
+    std::optional<zmq::socket_t> socket;
     try {
-        socket.connect(addr);
+        socket.emplace(context, zmq::socket_type::dealer);
+        setup_outgoing_socket(*socket, remote, use_ephemeral_routing_id);
+        socket->connect(addr);
     } catch (const zmq::error_t& e) {
         // Note that this failure cases indicates something serious went wrong that means zmq isn't
         // even going to try connecting (for example an unparseable remote address).
@@ -175,7 +177,7 @@ OxenMQ::proxy_connect_sn(std::string_view remote, std::string_view connect_hint,
     p.activity();
     connections_updated = true;
     outgoing_sn_conns.emplace_hint(outgoing_sn_conns.end(), p.conn_id, ConnectionID{remote});
-    auto it = connections.emplace_hint(connections.end(), p.conn_id, std::move(socket));
+    auto it = connections.emplace_hint(connections.end(), p.conn_id, *std::move(socket));
 
     return {&it->second, ""s};
 }
@@ -321,10 +323,11 @@ void OxenMQ::proxy_connect_remote(oxenc::bt_dict_consumer data) {
     OMQ_LOG(debug, "Establishing remote connection to ", remote,
             remote_pubkey.empty() ? " (NULL auth)" : " via CURVE expecting pubkey " + oxenc::to_hex(remote_pubkey));
 
-    zmq::socket_t sock{context, zmq::socket_type::dealer};
+    std::optional<zmq::socket_t> sock;
     try {
-        setup_outgoing_socket(sock, remote_pubkey, ephemeral_rid);
-        sock.connect(remote);
+        sock.emplace(context, zmq::socket_type::dealer);
+        setup_outgoing_socket(*sock, remote_pubkey, ephemeral_rid);
+        sock->connect(remote);
     } catch (const zmq::error_t &e) {
         proxy_schedule_reply_job([conn_id, on_failure=std::move(on_failure), what="connect() failed: "s+e.what()] {
                 on_failure(conn_id, std::move(what));
@@ -332,7 +335,7 @@ void OxenMQ::proxy_connect_remote(oxenc::bt_dict_consumer data) {
         return;
     }
 
-    auto &s = connections.emplace_hint(connections.end(), conn_id, std::move(sock))->second;
+    auto &s = connections.emplace_hint(connections.end(), conn_id, std::move(*sock))->second;
     connections_updated = true;
     OMQ_LOG(debug, "Opened new zmq socket to ", remote, ", conn_id ", conn_id, "; sending HI");
     send_direct_message(s, "HI");

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(tests
     test_failures.cpp
     test_inject.cpp
     test_requests.cpp
+    test_socket_limit.cpp
     test_tagged_threads.cpp
     test_timer.cpp
 )

--- a/tests/test_socket_limit.cpp
+++ b/tests/test_socket_limit.cpp
@@ -1,0 +1,43 @@
+#include "common.h"
+#include <oxenc/hex.h>
+
+using namespace oxenmq;
+
+TEST_CASE("zmq socket limit", "[zmq][socket-limit]") {
+    // Make sure setting .MAX_SOCKETS works as expected.  (This test was added when a bug was fixed
+    // that was causing it not to be applied).
+    std::string listen = random_localhost();
+    OxenMQ server{
+        "", "", // generate ephemeral keys
+        false, // not a service node
+        [](auto) { return ""; },
+    };
+    server.listen_plain(listen);
+    server.start();
+
+    std::atomic<int> failed = 0, good = 0, failed_toomany = 0;
+    OxenMQ client;
+    client.MAX_SOCKETS = 15;
+    client.start();
+
+    std::vector<ConnectionID> conns;
+    address server_addr{listen};
+    for (int i = 0; i < 16; i++)
+        client.connect_remote(server_addr,
+            [&](auto) { good++; },
+            [&](auto cid, auto msg) {
+                if (msg == "connect() failed: Too many open files")
+                    failed_toomany++;
+                else
+                    failed++;
+            });
+
+
+    wait_for([&] { return good > 0 && failed_toomany > 0; });
+    {
+        auto lock = catch_lock();
+        REQUIRE( good > 0 );
+        REQUIRE( failed == 0 );
+        REQUIRE( failed_toomany > 0 );
+    }
+}


### PR DESCRIPTION
MAX_SOCKETS wasn't working properly because ZMQ uses it when the context
is initialized, which happens when the first socket is constructed on
that context.

For OxenMQ, we had several sockets constructed on the context during
OxenMQ construction, which meant the context_t was being initialized
during OxenMQ construction, rather than during start(), and so setting
MAX_SOCKETS would have no effect and you'd always get the default.

This fixes it by making all the member variable zmq::socket_t's
default-constructed, then replacing them with proper zmq::socket_t's
during startup() so that we also defer zmq::context_t initialization to
the right place.

A second issue found during testing (also fixed here) is that the socket
worker threads use to communicate to the proxy could fail if the worker
socket creation would violate the zmq max sockets limit, which wound up
throwing an uncaught exception and aborting.  This pre-initializes (but
doesn't connect) all potential worker threads sockets during start() so
that the lazily-initialized worker thread will have one already set up
rather than having to create a new one (which could fail).