### PR TITLE
Attempt to fix a race condition

### DIFF
--- a/oxenmq/oxenmq.cpp
+++ b/oxenmq/oxenmq.cpp
@@ -431,7 +431,7 @@ OxenMQ::~OxenMQ() {
             // up, so signal them so that they can end themselves.
             {
                 std::lock_guard lock{tagged_startup_mutex};
-                tagged_go = true;
+                tagged_go = tagged_go_mode::SHUTDOWN;
             }
             tagged_cv.notify_all();
             for (auto& [run, busy, queue] : tagged_workers)

--- a/oxenmq/oxenmq.h
+++ b/oxenmq/oxenmq.h
@@ -788,7 +788,8 @@ private:
     /// then wait via this bool/c.v. to synchronize startup with the proxy thread.  This mutex isn't
     /// used after startup is complete.
     std::mutex tagged_startup_mutex;
-    bool tagged_go{false};
+    enum class tagged_go_mode { WAIT, GO, SHUTDOWN };
+    tagged_go_mode tagged_go = tagged_go_mode::WAIT;
     std::condition_variable tagged_cv;
 
 public:

--- a/oxenmq/proxy.cpp
+++ b/oxenmq/proxy.cpp
@@ -455,7 +455,7 @@ void OxenMQ::proxy_loop_init() {
         OMQ_LOG(debug, "Waiting for tagged workers");
         {
             std::unique_lock lock{tagged_startup_mutex};
-            tagged_go = true;
+            tagged_go = tagged_go_mode::GO;
         }
         tagged_cv.notify_all();
         std::unordered_set<std::string_view> waiting_on;

--- a/oxenmq/worker.cpp
+++ b/oxenmq/worker.cpp
@@ -71,9 +71,9 @@ void OxenMQ::worker_thread(unsigned int index, std::optional<std::string> tagged
         // is running).
         {
             std::unique_lock lock{tagged_startup_mutex};
-            tagged_cv.wait(lock, [this] { return tagged_go; });
+            tagged_cv.wait(lock, [this] { return tagged_go != tagged_go_mode::WAIT; });
         }
-        if (!proxy_thread.joinable()) // OxenMQ destroyed without starting
+        if (tagged_go == tagged_go_mode::SHUTDOWN) // OxenMQ destroyed without starting
             return;
         tagged_socket.emplace(context, zmq::socket_type::dealer);
     }


### PR DESCRIPTION
There's a very rare race condition where a tagged thread doesn't seem to exist when the proxy tries syncing startup with them, and so the proxy thread hangs in startup.

This is an attempt to fix it by avoiding looking at the proxy_thread variable (which probably isn't thread safe) in the worker's startup.

~~(This is currently just a guess though).~~

Looks like it solved it: this passed 3000 consecutive test suite runs with no stall in lokinet, whereas without it we were getting a failure roughly every 100-200 or so runs.