### PR TITLE
Bump ZMQ to latest release & propagate flags to build

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -81,8 +81,8 @@ local full_llvm(version) = debian_pipeline(
 [
   debian_pipeline('Debian sid (amd64)', docker_base + 'debian-sid', distro='sid'),
   debian_pipeline('Debian sid/Debug (amd64)', docker_base + 'debian-sid', build_type='Debug', distro='sid'),
-  clang(14),
-  full_llvm(14),
+  clang(16),
+  full_llvm(16),
   debian_pipeline('Debian buster (amd64)', docker_base + 'debian-buster'),
   debian_pipeline('Debian stable (i386)', docker_base + 'debian-stable/i386'),
   debian_pipeline('Debian sid (ARM64)', docker_base + 'debian-sid', arch='arm64', distro='sid'),

--- a/cmake/local-libzmq/LocalLibzmq.cmake
+++ b/cmake/local-libzmq/LocalLibzmq.cmake
@@ -1,7 +1,7 @@
 set(LIBZMQ_PREFIX ${CMAKE_BINARY_DIR}/libzmq)
-set(ZeroMQ_VERSION 4.3.4)
+set(ZeroMQ_VERSION 4.3.5)
 set(LIBZMQ_URL https://github.com/zeromq/libzmq/releases/download/v${ZeroMQ_VERSION}/zeromq-${ZeroMQ_VERSION}.tar.gz)
-set(LIBZMQ_HASH SHA512=e198ef9f82d392754caadd547537666d4fba0afd7d027749b3adae450516bcf284d241d4616cad3cb4ad9af8c10373d456de92dc6d115b037941659f141e7c0e)
+set(LIBZMQ_HASH SHA512=a71d48aa977ad8941c1609947d8db2679fc7a951e4cd0c3a1127ae026d883c11bd4203cf315de87f95f5031aec459a731aec34e5ce5b667b8d0559b157952541)
 
 message(${LIBZMQ_URL})
 
@@ -13,13 +13,23 @@ endif()
 
 file(MAKE_DIRECTORY ${LIBZMQ_PREFIX}/include)
 
+set(libzmq_compiler_args)
+foreach(lang C CXX)
+    foreach(thing COMPILER FLAGS COMPILER_LAUNCHER)
+        if(DEFINED CMAKE_${lang}_${thing})
+            list(APPEND libzmq_compiler_args "-DCMAKE_${lang}_${thing}=${CMAKE_${lang}_${thing}}")
+        endif()
+    endforeach()
+endforeach()
+
 include(ExternalProject)
 include(ProcessorCount)
 ExternalProject_Add(libzmq_external
     PREFIX ${LIBZMQ_PREFIX}
     URL ${LIBZMQ_URL}
     URL_HASH ${LIBZMQ_HASH}
-    CMAKE_ARGS -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER} -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+    CMAKE_ARGS ${libzmq_compiler_args}
+    -DCMAKE_BUILD_TYPE=Release
     -DWITH_LIBSODIUM=ON -DZMQ_BUILD_TESTS=OFF -DWITH_PERF_TOOL=OFF -DENABLE_DRAFTS=OFF
     -DBUILD_SHARED=OFF -DBUILD_STATIC=ON -DWITH_DOC=OFF -DCMAKE_INSTALL_PREFIX=${LIBZMQ_PREFIX}
     BUILD_BYPRODUCTS ${LIBZMQ_PREFIX}/${CMAKE_INSTALL_LIBDIR}/libzmq.a


### PR DESCRIPTION
- ZMQ 4.3.5
- The local zmq build was not propagating either ccache or CXX_FLAGS, and so was slower, and would not work properly if the parent was built using `-DCMAKE_CXX_FLAGS=-stdlib=libc++` (e.g. for a full llvm build, such as the one in lokinet).