### PR TITLE
Make epoll runtime configurable and disable by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ cmake_minimum_required(VERSION 3.7)
 set(CMAKE_OSX_DEPLOYMENT_TARGET 10.12 CACHE STRING "macOS deployment target (Apple clang only)")
 
 project(liboxenmq
-    VERSION 1.2.16
+    VERSION 1.2.17
     LANGUAGES CXX C)
 
 include(GNUInstallDirs)
@@ -47,7 +47,7 @@ endif()
 option(OXENMQ_BUILD_TESTS "Building and perform oxenmq tests" ${oxenmq_IS_TOPLEVEL_PROJECT})
 option(OXENMQ_INSTALL "Add oxenmq libraries and headers to cmake install target; defaults to ON if BUILD_SHARED_LIBS is enabled or we are the top-level project; OFF for a static subdirectory build" ${oxenmq_INSTALL_DEFAULT})
 option(OXENMQ_INSTALL_CPPZMQ "Install cppzmq header with oxenmq/ headers (requires OXENMQ_INSTALL)" ON)
-option(OXENMQ_USE_EPOLL "Use epoll for socket polling (requires Linux)" ${oxenmq_EPOLL_DEFAULT})
+option(OXENMQ_USE_EPOLL "Build with epoll support for socket polling (requires Linux)" ${oxenmq_EPOLL_DEFAULT})
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 

--- a/oxenmq/oxenmq.cpp
+++ b/oxenmq/oxenmq.cpp
@@ -237,6 +237,13 @@ void OxenMQ::start() {
 
     OMQ_LOG(info, "Initializing OxenMQ ", bind.empty() ? "remote-only" : "listener", " with pubkey ", oxenc::to_hex(pubkey));
 
+#ifdef OXENMQ_USE_EPOLL
+    using_epoll = USE_EPOLL;
+    OMQ_LOG(debug, "epoll ", using_epoll ? "enabled" : "disabled");
+#else
+    using_epoll = false;
+#endif
+
     assert(general_workers > 0);
     if (batch_jobs_reserved < 0)
         batch_jobs_reserved = (general_workers + 1) / 2;

--- a/oxenmq/oxenmq.h
+++ b/oxenmq/oxenmq.h
@@ -284,6 +284,13 @@ public:
      */
     std::chrono::milliseconds CONN_HEARTBEAT_TIMEOUT = 30s;
 
+    /** Whether to use epoll instead of regular ZMQ polling.  Has no effect if epoll is not
+     * supported.  Disabled by default; this can improve performance in cases where there are a very
+     * large number (i.e. many hundreds) of simultaneous outbound connections.  Not recommended
+     * otherwise.  This must be set *before* calling `start()`.
+     */
+    bool USE_EPOLL = false;
+
     /// Allows you to set options on the internal zmq context object.  For advanced use only.
     void set_zmq_context_option(zmq::ctxopt option, int value);
 
@@ -423,6 +430,10 @@ private:
     ///
     /// On Linux, when using epoll, this is not used.
     std::vector<zmq::pollitem_t> pollitems;
+
+    /// True if USE_EPOLL was set (before start()), to attempt to use epoll if supported.  Must not
+    /// be changed after `start()`.
+    bool using_epoll = false;
 
     /// On Linux, when using epoll, this tracks the epoll file descriptor.  Otherwise it does
     /// nothing.


### PR DESCRIPTION
Storage server is spitting out some occassional errors/crashes with this enabled, so this makes it opt-in rather than always on.

This effectively makes it experimental, which is fine (the only place this has any advantage is in the SPNS, and that will likely transition to quic in the not-too-distant future).