### PR TITLE
Fix inproc connections on active SNs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ cmake_minimum_required(VERSION 3.7)
 set(CMAKE_OSX_DEPLOYMENT_TARGET 10.12 CACHE STRING "macOS deployment target (Apple clang only)")
 
 project(liboxenmq
-    VERSION 1.2.20
+    VERSION 1.2.21
     LANGUAGES CXX C)
 
 include(GNUInstallDirs)

--- a/oxenmq/worker.cpp
+++ b/oxenmq/worker.cpp
@@ -306,15 +306,15 @@ void OxenMQ::proxy_to_worker(int64_t conn_id, zmq::socket_t& sock, std::vector<z
         // accepted.
         if (!peer->pubkey.empty())
             peer->service_node = active_service_nodes.count(peer->pubkey);
-    } else if (conn_id == inproc_listener_connid) {
-        tmp_peer.auth_level = AuthLevel::admin;
-        tmp_peer.pubkey = pubkey;
-        tmp_peer.service_node = active_service_nodes.count(pubkey);
-        peer = &tmp_peer;
     } else {
-        std::tie(tmp_peer.pubkey, tmp_peer.auth_level) = detail::extract_metadata(parts.back());
-        tmp_peer.service_node = tmp_peer.pubkey.size() == 32 && active_service_nodes.count(tmp_peer.pubkey);
-
+        if (conn_id == inproc_listener_connid) {
+            tmp_peer.auth_level = AuthLevel::admin;
+            tmp_peer.pubkey = pubkey;
+            tmp_peer.service_node = active_service_nodes.count(pubkey);
+        } else {
+            std::tie(tmp_peer.pubkey, tmp_peer.auth_level) = detail::extract_metadata(parts.back());
+            tmp_peer.service_node = tmp_peer.pubkey.size() == 32 && active_service_nodes.count(tmp_peer.pubkey);
+        }
         if (tmp_peer.service_node) {
             // It's a service node so we should have a peer_info entry; see if we can find one with
             // the same route, and if not, add one.


### PR DESCRIPTION
When the current node is in the active service node list, an inproc connection wasn't populating `peers` list, but when attempting to reply to the message, since it was a SN, we expected to find it in `peers`.

As a consequence, oxend interactive mode commands were not seeing the inproc connection when attempting to route the reply, and so attempted to do a remote address lookup and connection, which meant 1) interactive commands pointlessly opened a new external connection, and 2) if the connection failed (or there was no IP) then the command would fail completely and all interactive commands would just time out with errors about the pubkey being unreachable.

This fixes it by making inproc connections populate the peers list in the same way as other types of incoming connection so that we find and use that connection when replying to the local rpc commands.