### PR TITLE
set osx deployment target

### DIFF
--- a/cmake/local-libzmq/LocalLibzmq.cmake
+++ b/cmake/local-libzmq/LocalLibzmq.cmake
@@ -22,6 +22,10 @@ foreach(lang C CXX)
     endforeach()
 endforeach()
 
+if(CMAKE_OSX_DEPLOYMENT_TARGET)
+    list(APPEND libzmq_compiler_args "-DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}")
+endif()
+
 include(ExternalProject)
 include(ProcessorCount)
 ExternalProject_Add(libzmq_external


### PR DESCRIPTION
libzmq currently doesn't get told which OSX version to target, so if we are targeting OSX 11 in our builds it will still compile using the default then we get a linking error like this
```
ld: warning: object file (../../libzmq/lib/libzmq.a[101](zmtp_engine.cpp.o)) was built for newer 'macOS' version (15.0) than being linked (11.0)
```